### PR TITLE
[WIP] Update datastore location for HTTP-Trace

### DIFF
--- a/lib/msf/core/exploit/remote/http/trace.rb
+++ b/lib/msf/core/exploit/remote/http/trace.rb
@@ -1,0 +1,41 @@
+
+
+module Msf
+  class Exploit
+    class Remote
+      module HTTP
+        # This module provides functions for implementing 
+        # the HTTP-Trace functionality
+        module Trace
+          attr_accessor :ds_request
+          attr_accessor :ds_response
+
+          def initialize(info={})
+            super
+
+            register_advanced_options(
+              [
+                OptBool.new('HttpTrace', [ false, 'Show HTTP requests and responses', false ]),
+                OptBool.new('HttpTraceHeadersOnly', [false, 'Show HTTP headers only in HttpTrace', false]),
+                OptString.new('HttpTraceColors', [false, 'HTTP request and response colors for HttpTrace (unset to disable)', 'red/blu'])
+              ], self.class
+            )
+
+          end
+          
+          def assign_proc_httptrace()
+            http_client = Rex::Proto::Http::Client.new(datastore['RHOSTS'])
+            if datastore['HttpTrace']
+              self.ds_request = proc { |request| print_line("# Request ===== #{request}") }
+              self.ds_response = proc { |response| print_line("# Response ==== #{response}") }
+              http_client.set_procs_httptrace(@ds_request, @ds_response)
+            else
+              http_client.set_procs_httptrace(nil,nil)
+            end
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -14,6 +14,7 @@ module Msf
 module Exploit::Remote::HttpClient
 
   include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HTTP::Trace
 
   #
   # Initializes an exploit module that exploits a vulnerability in an HTTP
@@ -45,9 +46,6 @@ module Exploit::Remote::HttpClient
         OptBool.new('FingerprintCheck', [ false, 'Conduct a pre-exploit fingerprint verification', true]),
         OptString.new('DOMAIN', [ true, 'The domain to use for Windows authentication', 'WORKSTATION']),
         OptFloat.new('HttpClientTimeout', [false, 'HTTP connection and receive timeout']),
-        OptBool.new('HttpTrace', [false, 'Show the raw HTTP requests and responses', false]),
-        OptBool.new('HttpTraceHeadersOnly', [false, 'Show HTTP headers only in HttpTrace', false]),
-        OptString.new('HttpTraceColors', [false, 'HTTP request and response colors for HttpTrace (unset to disable)', 'red/blu']),
         OptString.new('SSLServerNameIndication', [ false, 'SSL/TLS Server Name Indication (SNI)', nil]),
       ], self.class
     )
@@ -363,34 +361,9 @@ module Exploit::Remote::HttpClient
     c = opts['client'] || connect(opts)
     r = opts[:cgi] ? c.request_cgi(opts) : c.request_raw(opts)
 
-    if datastore['HttpTrace']
-      request_color, response_color =
-        (datastore['HttpTraceColors'] || '').split('/').map { |color| "%bld%#{color}" }
-
-      request = r.to_s(headers_only: datastore['HttpTraceHeaders'])
-
-      print_line('#' * 20)
-      print_line('# Request:')
-      print_line('#' * 20)
-      print_line("%clr#{request_color}#{request}%clr")
-    end
-
+    assign_proc_httptrace()
     res = c.send_recv(r, actual_timeout)
-
-    if datastore['HttpTrace']
-      print_line('#' * 20)
-      print_line('# Response:')
-      print_line('#' * 20)
-
-      if res
-        response = res.to_terminal_output(headers_only: datastore['HttpTraceHeadersOnly'])
-
-        print_line("%clr#{response_color}#{response}%clr")
-      else
-        print_line('No response received')
-      end
-    end
-
+   
     disconnect(c) if disconnect
 
     res

--- a/modules/auxiliary/scanner/http/buffalo_login.rb
+++ b/modules/auxiliary/scanner/http/buffalo_login.rb
@@ -37,6 +37,7 @@ class MetasploitModule < Msf::Auxiliary
       password: datastore['PASSWORD']
     )
 
+    assign_proc_httptrace()
     scanner = Metasploit::Framework::LoginScanner::Buffalo.new(
       configure_http_login_scanner(
         cred_details: cred_collection,


### PR DESCRIPTION
Implemented datastore in a new mixin at **Msf::Exploit::Remote::HTTP::Trace** location. Still working on passing the proc from **Msf::Exploit::Remote::HTTP::Trace** to **Exploit::Remote::HttpClient** and then to **Rex::Proto::Http::Client**.