### PR TITLE
Add procs required for logging HTTP requests and responses in Login Scanners

### DIFF
--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -250,7 +250,7 @@ module Metasploit
           if http_trace
             proc_httptrace = proc { |request, response|
               request_color, response_color =
-                (http_trace_colors || '').split('/').map { |color| "%bld%#{color}" }
+                (http_trace_colors || 'red/blu').split('/').map { |color| "%bld%#{color}" }
               
               request = request.to_s(headers_only: http_trace_headers_only)
               print_line('#' * 20)

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -176,7 +176,17 @@ module Metasploit
         # @return [String]
         attr_accessor :http_password
 
+        # @!attribute http_trace
+        # @return [Boolean] Whether HTTP requests and responses need to be logged
         attr_accessor :http_trace
+
+        # @!attribute http_trace
+        # @return [Boolean] Whether only HTTP headers need to be logged
+        attr_accessor :http_trace_headers_only
+
+        # @!attribute_http_trace_colors
+        # @return [String] Pair of colors for requests and responses
+        attr_accessor :http_trace_colors
 
 
         validates :uri, presence: true, length: { minimum: 1 }
@@ -238,11 +248,29 @@ module Metasploit
           res = nil
           
           if http_trace
-            http_trace_proc = proc { |request, response|
-              print_line("# Request ==== #{request}")
-              print_line("# Response ==== #{response}")
+            proc_httptrace = proc { |request, response|
+              request_color, response_color =
+                (http_trace_colors || '').split('/').map { |color| "%bld%#{color}" }
+              
+              request = request.to_s(headers_only: http_trace_headers_only)
+              print_line('#' * 20)
+              print_line('# Request:')
+              print_line('#' * 20)
+              print_line("%clr#{request_color}#{request}%clr")
+              
+              print_line('#' * 20)
+              print_line('# Response:')
+              print_line('#' * 20)
+              
+              if response
+                response = response.to_terminal_output(headers_only: http_trace_headers_only)
+                print_line("%clr#{response_color}#{response}%clr")
+              else
+                print_line('No response received')
+              end
             }
           end
+
 
           cli = Rex::Proto::Http::Client.new(
             rhost,
@@ -253,7 +281,7 @@ module Metasploit
             cli_proxies,
             username,
             password,
-            http_trace_proc: http_trace_proc
+            http_trace_proc: proc_httptrace
           )
           configure_http_client(cli)
 
@@ -320,9 +348,11 @@ module Metasploit
         # Rex::Proto::Http::Client configuration parameters.
         def configure_http_client(http_client)
           http_client.set_config(
-            'vhost'                  => vhost || host,
-            'agent'                  => user_agent,
-            'http_trace'             => http_trace
+            'vhost'                   => vhost || host,
+            'agent'                   => user_agent,
+            'http_trace'              => http_trace,
+            'http_trace_headers_only' => http_trace_headers_only,
+            'http_trace_colors'       => http_trace_colors
           )
 
           possible_params = {

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -154,7 +154,7 @@ module Exploit::Remote::HttpClient
     if datastore['HttpTrace']
       proc_httptrace = proc { |request, response| 
         request_color, response_color = 
-          (datastore['HttpTraceColors'] || '').split('/').map { |color| "%bld%#{color}" }
+          (datastore['HttpTraceColors'] || 'red/blu').split('/').map { |color| "%bld%#{color}" }
         
         request = request.to_s(headers_only: datastore['HttpTraceHeadersOnly'])
         print_line('#' * 20)

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -153,8 +153,25 @@ module Exploit::Remote::HttpClient
 
     if datastore['HttpTrace']
       proc_httptrace = proc { |request, response| 
-        print_line("# Request ===== #{request}") 
-        print_line("# Response ===== #{response}") 
+        request_color, response_color = 
+          (datastore['HttpTraceColors'] || '').split('/').map { |color| "%bld%#{color}" }
+        
+        request = request.to_s(headers_only: datastore['HttpTraceHeadersOnly'])
+        print_line('#' * 20)
+        print_line('# Request:')
+        print_line('#' * 20)
+        print_line("%clr#{request_color}#{request}%clr")
+
+        print_line('#' * 20)
+        print_line('# Response:')
+        print_line('#' * 20)
+        
+        if response
+          response = response.to_terminal_output(headers_only: datastore['HttpTraceHeadersOnly'])
+          print_line("%clr#{response_color}#{response}%clr")
+        else
+          print_line('No response received')
+        end
       }
     end
 
@@ -280,6 +297,8 @@ module Exploit::Remote::HttpClient
       port:                          rport,
       ssl:                           ssl,
       http_trace:                    http_trace,
+      http_trace_colors:             http_trace_colors,
+      http_trace_headers_only:       http_trace_headers_only,
       ssl_version:                   ssl_version,
       proxies:                       datastore['PROXIES'],
       framework:                     framework,
@@ -712,6 +731,20 @@ module Exploit::Remote::HttpClient
   #
   def http_trace
     datastore['HttpTrace']
+  end
+
+  #
+  # Returns the datastore option for HttpTraceHeadersOnly
+  #
+  def http_trace_headers_only
+    datastore['HttpTraceHeadersOnly']
+  end
+
+  # 
+  # Returns the datastore option for HttpTraceColors
+  #
+  def http_trace_colors
+    datastore['HttpTraceColors']
   end
 
 

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -74,6 +74,8 @@ module Exploit::Remote::HttpClient
         OptInt.new('HTTP::pad_get_params_count', [false, 'How many fake query string variables to insert into the request', 16]),
         OptBool.new('HTTP::pad_post_params', [false, 'Insert random, fake post variables into the request', false]),
         OptInt.new('HTTP::pad_post_params_count', [false, 'How many fake post variables to insert into the request', 16]),
+        OptBool.new('HTTP::shuffle_get_params', [false, 'Randomize order of GET parameters', false]),
+        OptBool.new('HTTP::shuffle_post_params', [false, 'Randomize order of POST parameters', false]),
         OptBool.new('HTTP::uri_fake_end', [false, 'Add a fake end of URI (eg: /%20HTTP/1.0/../../)', false]),
         OptBool.new('HTTP::uri_fake_params_start', [false, 'Add a fake start of params to the URI (eg: /%3fa=b/../)', false]),
         OptBool.new('HTTP::header_folding', [false, 'Enable folding of HTTP headers', false])
@@ -149,6 +151,13 @@ module Exploit::Remote::HttpClient
     client_username = opts['username'] || datastore['HttpUsername'] || ''
     client_password = opts['password'] || datastore['HttpPassword'] || ''
 
+    if datastore['HttpTrace']
+      proc_httptrace = proc { |request, response| 
+        print_line("# Request ===== #{request}") 
+        print_line("# Response ===== #{response}") 
+      }
+    end
+
     nclient = Rex::Proto::Http::Client.new(
       opts['rhost'] || rhost,
       (opts['rport'] || rport).to_i,
@@ -161,7 +170,8 @@ module Exploit::Remote::HttpClient
       proxies,
       client_username,
       client_password,
-      comm: opts['comm']
+      comm: opts['comm'],
+      http_trace_proc: proc_httptrace
     )
 
 
@@ -192,6 +202,8 @@ module Exploit::Remote::HttpClient
       'pad_get_params_count'   => datastore['HTTP::pad_get_params_count'],
       'pad_post_params'        => datastore['HTTP::pad_post_params'],
       'pad_post_params_count'  => datastore['HTTP::pad_post_params_count'],
+      'shuffle_get_params'     => datastore['HTTP::shuffle_get_params'],
+      'shuffle_post_params'    => datastore['HTTP::shuffle_post_params'],
       'uri_fake_end'           => datastore['HTTP::uri_fake_end'],
       'uri_fake_params_start'  => datastore['HTTP::uri_fake_params_start'],
       'header_folding'         => datastore['HTTP::header_folding'],
@@ -267,6 +279,7 @@ module Exploit::Remote::HttpClient
       host:                          rhost,
       port:                          rport,
       ssl:                           ssl,
+      http_trace:                    http_trace,
       ssl_version:                   ssl_version,
       proxies:                       datastore['PROXIES'],
       framework:                     framework,
@@ -293,6 +306,8 @@ module Exploit::Remote::HttpClient
       evade_pad_get_params_count:    datastore['HTTP::pad_get_params_count'],
       evade_pad_post_params:         datastore['HTTP::pad_post_params'],
       evade_pad_post_params_count:   datastore['HTTP::pad_post_params_count'],
+      evade_shuffle_get_params:      datastore['HTTP::shuffle_get_params'],
+      evade_shuffle_post_params:     datastore['HTTP::shuffle_post_params'],
       evade_uri_fake_end:            datastore['HTTP::uri_fake_end'],
       evade_uri_fake_params_start:   datastore['HTTP::uri_fake_params_start'],
       evade_header_folding:          datastore['HTTP::header_folding'],
@@ -363,33 +378,8 @@ module Exploit::Remote::HttpClient
     c = opts['client'] || connect(opts)
     r = opts[:cgi] ? c.request_cgi(opts) : c.request_raw(opts)
 
-    if datastore['HttpTrace']
-      request_color, response_color =
-        (datastore['HttpTraceColors'] || '').split('/').map { |color| "%bld%#{color}" }
-
-      request = r.to_s(headers_only: datastore['HttpTraceHeaders'])
-
-      print_line('#' * 20)
-      print_line('# Request:')
-      print_line('#' * 20)
-      print_line("%clr#{request_color}#{request}%clr")
-    end
-
+    
     res = c.send_recv(r, actual_timeout)
-
-    if datastore['HttpTrace']
-      print_line('#' * 20)
-      print_line('# Response:')
-      print_line('#' * 20)
-
-      if res
-        response = res.to_terminal_output(headers_only: datastore['HttpTraceHeadersOnly'])
-
-        print_line("%clr#{response_color}#{response}%clr")
-      else
-        print_line('No response received')
-      end
-    end
 
     disconnect(c) if disconnect
 
@@ -715,6 +705,13 @@ module Exploit::Remote::HttpClient
   #
   def proxies
     datastore['Proxies']
+  end
+
+  # 
+  # Returns the configured datastore option for HttpTrace
+  #
+  def http_trace
+    datastore['HttpTrace']
   end
 
 

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -21,7 +21,7 @@ class Client
   #
   # Creates a new client instance
   #
-  def initialize(host, port = 80, context = {}, ssl = nil, ssl_version = nil, proxies = nil, username = '', password = '', comm: nil)
+  def initialize(host, port = 80, context = {}, ssl = nil, ssl_version = nil, proxies = nil, username = '', password = '', comm: nil, http_trace_proc: nil)
     self.hostname = host
     self.port     = port.to_i
     self.context  = context
@@ -31,6 +31,7 @@ class Client
     self.username = username
     self.password = password
     self.comm = comm
+    self.http_trace_proc = http_trace_proc
 
     # Take ClientRequest's defaults, but override with our own
     self.config = Http::ClientRequest::DefaultConfig.merge({
@@ -63,6 +64,8 @@ class Client
       'pad_get_params_count'   => 'integer',
       'pad_post_params'        => 'bool',
       'pad_post_params_count'  => 'integer',
+      'shuffle_get_params'     => 'bool',
+      'shuffle_post_params'    => 'bool',
       'uri_fake_end'           => 'bool',
       'uri_fake_params_start'  => 'bool',
       'header_folding'         => 'bool',
@@ -230,17 +233,10 @@ class Client
       req = req.opts['ntlm_transform_request'].call(self.ntlm_client, req)
     end
 
-    # TODO: Pass the datastore options related to HTTP-Trace here,
-    # while creating the object of the wrapper class. 
-    # e.g. HttpTrace, HttpTraceHeadersOnly, HttpTraceColors
-    http_trace_object = Rex::Proto::Http::HttpTrace.new(true)
-    # Use HTTP-Trace for logging requests sent from client
-    http_trace_object.use_http_trace_request(req, req.opts['method'])
     send_request(req, t)
 
     res = read_response(t)
-    # Use HTTP-Trace for logging responses received to the client
-    http_trace_object.use_http_trace_response(res, res.code)
+    httptrace_use_callback(req, res)
     if req.respond_to?(:opts) && req.opts['ntlm_transform_response'] && self.ntlm_client
       req.opts['ntlm_transform_response'].call(self.ntlm_client, res)
     end
@@ -686,6 +682,10 @@ class Client
     nil
   end
 
+  def httptrace_use_callback(req, res)
+    self.http_trace_proc.call(req, res) unless self.http_trace_proc.nil?
+  end
+
   #
   # An optional comm to use for creating the underlying socket.
   #
@@ -728,6 +728,9 @@ class Client
 
   # When parsing the request, thunk off the first response from the server, since junk
   attr_accessor :junk_pipeline
+
+  # HTTP-Trace
+  attr_accessor :http_trace_proc
 
 protected
 


### PR DESCRIPTION
Works done in this PR:

1. **Msf::Core::Exploit::Remote::HttpClient** : All the datastore options related to HTTP-Trace are implemented in the **Msf::Core::Exploit::Remote::HttpClient** mixin. In that mixin, I have defined three methods ( **http_trace()**, **http_trace_headers_only()**, **http_trace_colors()**) which return the value of the respective datastore option as set by the user. Now these methods can be called by other libraries in the **Metasploit::** namespace or **Rex::** namespace whenever they require to check the value of **datastore['HttpTrace']**. The earlier code in this mixin directly prints out the requests and responses by checking the value of **datastore['HttpTrace']**. But with this PR, a proc is defined in the **Msf::Core::Exploit::Remote::HttpClient** mixin which takes the request and response as parameter and prints them to the console. This proc is then forwarded to **Rex::Proto::Http::Client** while creating its instance and the **Rex::Proto::Http::Client** takes care of making a callback to this proc with the request and response objects.  

2. **Metasploit::Framework::LoginScanner::Http** : In this library, we have just defined a proc which takes the request and response objects as parameters and prints them to the console by checking the value of datastore['HttpTrace'] (similar to the proc in **Msf::Core::Exploit::Remote::HttpClient**). Similarly, it then forwards this proc to the **Rex::Proto::Http::Client** while creating an instance. The only difference between this proc and the one in **Msf::** namespace is that this proc checks the value of datastore['HttpTrace'] by making a method call to the **http_trace** method defined in the **Msf::Exploit::Remote::HttpClient** rather than directly accessing it via datastore['HttpTrace']. 
Not all login scanners access the **Msf::Core::Exploit::Remote::HttpClient** mixin to send requests and responses. A majority of the Login Scanners access the **Metasploit::Framework::LoginScanner::Http** library to do so. Thus, it is essential to have the HTTP-Trace related proc defined here as well. 

3. **Rex::Proto::Http::Client** : This Rex client accepts the http_trace_proc as a parameter in the **initialize()** method and assigns it to an instance variable. Then it checks if the proc received is not nil, then makes a callback to that proc by passing the current request and response object in the scope. 

In this way, any other library can use HTTP-Trace functionality by calling these methods (**http_trace()**, **http_trace_headers_only()**, **http_trace_colors()**), then defining the proc and passing it to the **Rex::Proto::Http::Client**.