### PR TITLE
Refactor type-2 login scanners

### DIFF
--- a/lib/metasploit/framework/login_scanner/axis2.rb
+++ b/lib/metasploit/framework/login_scanner/axis2.rb
@@ -16,12 +16,6 @@ module Metasploit
 
         # (see Base#attempt_login)
         def attempt_login(credential)
-          http_client = Rex::Proto::Http::Client.new(
-            host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies, http_username, http_password
-          )
-
-          configure_http_client(http_client)
-
           result_opts = {
               credential: credential,
               host: host,
@@ -35,14 +29,18 @@ module Metasploit
           end
 
           begin
-            http_client.connect
-            body = "userName=#{Rex::Text.uri_encode(credential.public)}&password=#{Rex::Text.uri_encode(credential.private)}&submit=+Login+"
-            request = http_client.request_cgi(
+            # Refactor to access Metasploit::Framework::LoginScanner::HTTP#send_request()
+            # to send request to the HTTP server and obtain a response      
+            response = send_request({
               'uri' => uri,
-              'method' => "POST",
-              'data' => body,
-            )
-            response = http_client.send_recv(request)
+              'method' => 'POST',
+              'vars_post' =>
+               {
+                 'userName' => Rex::Text.uri_encode(credential.public),
+                 'password' => Rex::Text.uri_encode(credential.private),
+                 'submit' => '+Login+'
+               }
+            })
 
             if response && response.code == 200 && response.body.include?("upload")
               result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: response)

--- a/lib/metasploit/framework/login_scanner/buffalo.rb
+++ b/lib/metasploit/framework/login_scanner/buffalo.rb
@@ -34,10 +34,7 @@ module Metasploit
             result_opts[:service_name] = 'http'
           end
           begin
-            cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, http_username, http_password)
-            configure_http_client(cli)
-            cli.connect
-            req = cli.request_cgi({
+            res = send_request({
               'method'=>'POST',
               'uri'=>'/dynamic.pl',
               'vars_post'=> {
@@ -46,7 +43,7 @@ module Metasploit
                 'password'=>credential.private
                 }
             })
-            res = cli.send_recv(req)
+
             body = JSON.parse(res.body)
             if res && body.has_key?('success') && body['success']
               result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: res.body)

--- a/lib/metasploit/framework/login_scanner/chef_webui.rb
+++ b/lib/metasploit/framework/login_scanner/chef_webui.rb
@@ -46,7 +46,7 @@ module Metasploit
         # (see Base#check_setup)
         def check_setup
           begin
-            res = send_request({'uri' => normalize_uri('/users/login')})
+            res = pass_request({'uri' => normalize_uri('/users/login')})
             return "Connection failed" if res.nil?
 
             if res.code != 200
@@ -68,12 +68,8 @@ module Metasploit
         #
         # @param (see Rex::Proto::Http::Resquest#request_raw)
         # @return [Rex::Proto::Http::Response] The HTTP response
-        def send_request(opts)
-          cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => self}, ssl, ssl_version, proxies, http_username, http_password)
-          configure_http_client(cli)
-          cli.connect
-          req = cli.request_raw(opts)
-          res = cli.send_recv(req)
+        def pass_request(opts) 
+          res = send_request(opts)
 
           # Save the session ID cookie
           if res && res.get_cookies =~ /(_\w+_session)=([^;$]+)/i
@@ -106,7 +102,7 @@ module Metasploit
             }
           }
 
-          send_request(opts)
+          pass_request(opts)
         end
 
 
@@ -119,7 +115,7 @@ module Metasploit
         def try_login(credential)
 
           # Obtain a CSRF token first
-          res = send_request({'uri' => normalize_uri('/users/login')})
+          res = pass_request({'uri' => normalize_uri('/users/login')})
           unless (res && res.code == 200 && res.body =~ /input name="authenticity_token" type="hidden" value="([^"]+)"/m)
             return {:status => Metasploit::Model::Login::Status::UNTRIED, :proof => res.body}
           end
@@ -135,7 +131,7 @@ module Metasploit
                 'Cookie'  => "#{self.session_name}=#{self.session_id}"
               }
             }
-            res = send_request(opts)
+            res = pass_request(opts)
             if (res && res.code == 200 && res.body.to_s =~ /New password for the User/)
               return {:status => Metasploit::Model::Login::Status::SUCCESSFUL, :proof => res.body}
             end

--- a/lib/metasploit/framework/login_scanner/chef_webui.rb
+++ b/lib/metasploit/framework/login_scanner/chef_webui.rb
@@ -46,7 +46,7 @@ module Metasploit
         # (see Base#check_setup)
         def check_setup
           begin
-            res = pass_request({
+            res = send_request_and_grab_cookie({
               'uri' => normalize_uri('/users/login'),
               'requestcgi' => false
             })
@@ -71,7 +71,7 @@ module Metasploit
         #
         # @param (see Rex::Proto::Http::Resquest#request_raw)
         # @return [Rex::Proto::Http::Response] The HTTP response
-        def pass_request(opts) 
+        def send_request_and_grab_cookie(opts) 
           res = send_request(opts)
 
           # Save the session ID cookie
@@ -106,7 +106,7 @@ module Metasploit
             'requestcgi' => false
           }
 
-          pass_request(opts)
+          send_request_and_grab_cookie(opts)
         end
 
 
@@ -119,7 +119,7 @@ module Metasploit
         def try_login(credential)
 
           # Obtain a CSRF token first
-          res = pass_request({
+          res = send_request_and_grab_cookie({
             'uri' => normalize_uri('/users/login'),
             'requestcgi' => false  
           })
@@ -139,7 +139,7 @@ module Metasploit
               },
               'requestcgi' => false
             }
-            res = pass_request(opts)
+            res = send_request_and_grab_cookie(opts)
             if (res && res.code == 200 && res.body.to_s =~ /New password for the User/)
               return {:status => Metasploit::Model::Login::Status::SUCCESSFUL, :proof => res.body}
             end

--- a/lib/metasploit/framework/login_scanner/chef_webui.rb
+++ b/lib/metasploit/framework/login_scanner/chef_webui.rb
@@ -46,7 +46,10 @@ module Metasploit
         # (see Base#check_setup)
         def check_setup
           begin
-            res = pass_request({'uri' => normalize_uri('/users/login')})
+            res = pass_request({
+              'uri' => normalize_uri('/users/login'),
+              'requestcgi' => false
+            })
             return "Connection failed" if res.nil?
 
             if res.code != 200
@@ -99,7 +102,8 @@ module Metasploit
             'headers' => {
               'Content-Type'   => 'application/x-www-form-urlencoded',
               'Cookie'         => "#{self.session_name}=#{self.session_id}"
-            }
+            },
+            'requestcgi' => false
           }
 
           pass_request(opts)
@@ -115,7 +119,10 @@ module Metasploit
         def try_login(credential)
 
           # Obtain a CSRF token first
-          res = pass_request({'uri' => normalize_uri('/users/login')})
+          res = pass_request({
+            'uri' => normalize_uri('/users/login'),
+            'requestcgi' => false  
+          })
           unless (res && res.code == 200 && res.body =~ /input name="authenticity_token" type="hidden" value="([^"]+)"/m)
             return {:status => Metasploit::Model::Login::Status::UNTRIED, :proof => res.body}
           end
@@ -129,7 +136,8 @@ module Metasploit
               'method'  => 'GET',
               'headers' => {
                 'Cookie'  => "#{self.session_name}=#{self.session_id}"
-              }
+              },
+              'requestcgi' => false
             }
             res = pass_request(opts)
             if (res && res.code == 200 && res.body.to_s =~ /New password for the User/)

--- a/lib/metasploit/framework/login_scanner/glassfish.rb
+++ b/lib/metasploit/framework/login_scanner/glassfish.rb
@@ -30,7 +30,10 @@ module Metasploit
         # (see Base#check_setup)
         def check_setup
           begin
-            res = pass_request({'uri' => '/common/index.jsf'})
+            res = pass_request({
+              'uri' => '/common/index.jsf',
+              'requestcgi' => false
+            })
             return "Connection failed" if res.nil?
             if !([200, 302].include?(res.code))
               return "Unexpected HTTP response code #{res.code} (is this really Glassfish?)"
@@ -40,7 +43,10 @@ module Metasploit
             # same port.
             if !self.ssl && res.headers['Location'] =~ /^https:/
               self.ssl = true
-              res = pass_request({'uri' => '/common/index.jsf'})
+              res = pass_request({
+                'uri' => '/common/index.jsf',
+                'requestcgi' => false
+              })
               if res.nil?
                 return "Connection failed after SSL redirection"
               end
@@ -49,7 +55,10 @@ module Metasploit
               end
             end
 
-            res = pass_request({'uri' => '/login.jsf'})
+            res = pass_request({
+              'uri' => '/login.jsf',
+              'requestcgi' => false
+            })
             return "Connection failed" if res.nil?
             extract_version(res.headers['Server'])
 
@@ -106,7 +115,8 @@ module Metasploit
             'headers' => {
               'Content-Type'   => 'application/x-www-form-urlencoded',
               'Cookie'         => "JSESSIONID=#{self.jsession}",
-            }
+            },
+            'requestcgi' => false
           }
 
           pass_request(opts)
@@ -127,7 +137,8 @@ module Metasploit
               'method'  => 'GET',
               'headers' => {
                 'Cookie'  => "JSESSIONID=#{self.jsession}"
-              }
+              },
+              'requestcgi' => false
             }
             res = pass_request(opts)
             p = /<title>Deploy Enterprise Applications\/Modules/
@@ -169,7 +180,8 @@ module Metasploit
               'method'  => 'GET',
               'headers' => {
                 'Cookie'  => "JSESSIONID=#{self.jsession}"
-              }
+              },
+              'requestcgi' => false
             }
             res = pass_request(opts)
 

--- a/lib/metasploit/framework/login_scanner/glassfish.rb
+++ b/lib/metasploit/framework/login_scanner/glassfish.rb
@@ -30,7 +30,7 @@ module Metasploit
         # (see Base#check_setup)
         def check_setup
           begin
-            res = pass_request({
+            res = send_request_and_grab_cookie({
               'uri' => '/common/index.jsf',
               'requestcgi' => false
             })
@@ -43,7 +43,7 @@ module Metasploit
             # same port.
             if !self.ssl && res.headers['Location'] =~ /^https:/
               self.ssl = true
-              res = pass_request({
+              res = send_request_and_grab_cookie({
                 'uri' => '/common/index.jsf',
                 'requestcgi' => false
               })
@@ -55,7 +55,7 @@ module Metasploit
               end
             end
 
-            res = pass_request({
+            res = send_request_and_grab_cookie({
               'uri' => '/login.jsf',
               'requestcgi' => false
             })
@@ -76,7 +76,7 @@ module Metasploit
         #
         # @param (see Rex::Proto::Http::Resquest#request_raw)
         # @return [Rex::Proto::Http::Response] The HTTP response
-        def pass_request(opts)
+        def send_request_and_grab_cookie(opts)
           res = send_request(opts)
 
           # Found a cookie? Set it. We're going to need it.
@@ -119,7 +119,7 @@ module Metasploit
             'requestcgi' => false
           }
 
-          pass_request(opts)
+          send_request_and_grab_cookie(opts)
         end
 
 
@@ -140,7 +140,7 @@ module Metasploit
               },
               'requestcgi' => false
             }
-            res = pass_request(opts)
+            res = send_request_and_grab_cookie(opts)
             p = /<title>Deploy Enterprise Applications\/Modules/
             if (res && res.code.to_i == 200 && res.body.match(p) != nil)
               return {:status => Metasploit::Model::Login::Status::SUCCESSFUL, :proof => res.body}
@@ -183,7 +183,7 @@ module Metasploit
               },
               'requestcgi' => false
             }
-            res = pass_request(opts)
+            res = send_request_and_grab_cookie(opts)
 
             p = /<title>Deploy Applications or Modules/
             if (res && res.code.to_i == 200 && res.body.match(p) != nil)

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -291,7 +291,13 @@ module Metasploit
 
           begin
             cli.connect
-            req = cli.request_cgi(opts)
+            # Send CGI compatible request by default
+            req = if opts['requestcgi'].nil? || opts['requestcgi']
+                    cli.request_cgi(opts)
+                  else
+                    cli.request_raw(opts)
+                  end
+
             # Authenticate by default
             res = if opts['authenticate'].nil? || opts['authenticate']
                     cli.send_recv(req)

--- a/lib/metasploit/framework/login_scanner/ipboard.rb
+++ b/lib/metasploit/framework/login_scanner/ipboard.rb
@@ -16,12 +16,7 @@ module Metasploit
         attr_accessor :http_password
 
         # (see Base#attempt_login)
-        def attempt_login(credential)
-          http_client = Rex::Proto::Http::Client.new(
-              host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies, self.http_username, self.http_password
-          )
-          configure_http_client(http_client)
-
+        def attempt_login(credential) 
           result_opts = {
               credential: credential,
               host: host,
@@ -35,14 +30,11 @@ module Metasploit
           end
 
           begin
-            http_client.connect
 
-            nonce_request = http_client.request_cgi(
+            nonce_response = send_request({
                 'uri' => uri,
                 'method'  => 'GET'
-            )
-
-            nonce_response = http_client.send_recv(nonce_request)
+            })
 
             if nonce_response.body =~ /name='auth_key'\s+value='.*?((?:[a-z0-9]*))'/i
               server_nonce = $1
@@ -55,7 +47,7 @@ module Metasploit
 
               auth_uri = "#{base_uri}/index.php"
 
-              request = http_client.request_cgi(
+              response = send_request({
                 'uri' => auth_uri,
                 'method'  => 'POST',
                 'vars_get' => {
@@ -69,9 +61,7 @@ module Metasploit
                   'ips_username' => credential.public,
                   'ips_password' => credential.private
                 }
-              )
-
-              response = http_client.send_recv(request)
+              })
 
               if response && response.get_cookies.include?('ipsconnect') && response.get_cookies.include?('coppa')
                 result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: response)

--- a/lib/metasploit/framework/login_scanner/jenkins.rb
+++ b/lib/metasploit/framework/login_scanner/jenkins.rb
@@ -37,10 +37,7 @@ module Metasploit
             result_opts[:service_name] = 'http'
           end
           begin
-            cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies, http_username, http_password)
-            configure_http_client(cli)
-            cli.connect
-            req = cli.request_cgi({
+            res = send_request({
               'method'=> method,
               'uri'=> uri,
               'vars_post'=> {
@@ -48,7 +45,7 @@ module Metasploit
                 'j_password'=> credential.private
                 }
             })
-            res = cli.send_recv(req)
+
             if res && res.headers['location'] && !res.headers['location'].include?('loginError')
               result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: res.headers)
             else

--- a/lib/metasploit/framework/login_scanner/mybook_live.rb
+++ b/lib/metasploit/framework/login_scanner/mybook_live.rb
@@ -33,17 +33,16 @@ module Metasploit
             result_opts[:service_name] = 'http'
           end
           begin
-            cred = Rex::Text.uri_encode(credential.private)
-            body = "data%5BLogin%5D%5Bowner_name%5D=admin&data%5BLogin%5D%5Bowner_passwd%5D=#{cred}"
-            cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, http_username, http_password)
-            configure_http_client(cli)
-            cli.connect
-            req = cli.request_cgi(
+            cred = Rex::Text.uri_encode(credential.private) 
+            res = send_request({
               'method' => method,
               'uri' => uri,
-              'data' => body
-            )
-            res = cli.send_recv(req)
+              'vars_post' => {
+                 'data%5BLogin%5D%5Bowner_name%5D' => 'admin',
+                 'data%5BLogin%5D%5Bowner_passwd%5D' => cred
+              }
+            })
+
             if res && res.code == 302 && res.headers['location'] && res.headers['location'].include?('UI')
               result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: res.headers)
             elsif res.nil?

--- a/lib/metasploit/framework/login_scanner/octopusdeploy.rb
+++ b/lib/metasploit/framework/login_scanner/octopusdeploy.rb
@@ -33,18 +33,17 @@ module Metasploit
           else
             result_opts[:service_name] = 'http'
           end
-          begin
-            json_post_data = JSON.pretty_generate({ Username: credential.public, Password: credential.private })
-            cli = Rex::Proto::Http::Client.new(host, port, { 'Msf' => framework, 'MsfExploit' => framework_module }, ssl, ssl_version, http_username, http_password)
-            configure_http_client(cli)
-            cli.connect
-            req = cli.request_cgi(
+          begin 
+            res = send_request({
               'method' => 'POST',
               'uri' => uri,
               'ctype' => 'application/json',
-              'data' => json_post_data
-            )
-            res = cli.send_recv(req)
+              'vars_post' => {
+                'Username' => credential.public,
+                'Password' => credential.private
+              }
+            })
+
             body = JSON.parse(res.body)
             if res && res.code == 200 && body.key?('IsActive') && body['IsActive']
               result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: res.body)

--- a/lib/metasploit/framework/login_scanner/octopusdeploy.rb
+++ b/lib/metasploit/framework/login_scanner/octopusdeploy.rb
@@ -34,14 +34,12 @@ module Metasploit
             result_opts[:service_name] = 'http'
           end
           begin 
+            json_post_data = JSON.pretty_generate({ Username: credential.public, Password: credential.private })
             res = send_request({
               'method' => 'POST',
               'uri' => uri,
               'ctype' => 'application/json',
-              'vars_post' => {
-                'Username' => credential.public,
-                'Password' => credential.private
-              }
+              'data' => json_post_data
             })
 
             body = JSON.parse(res.body)

--- a/lib/metasploit/framework/login_scanner/smh.rb
+++ b/lib/metasploit/framework/login_scanner/smh.rb
@@ -33,7 +33,7 @@ module Metasploit
           res = nil
 
           begin
-            res = send_request(req)
+            res = send_request(req_opts)
 
           rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, ::EOFError, ::Timeout::Error => e
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)

--- a/lib/metasploit/framework/login_scanner/smh.rb
+++ b/lib/metasploit/framework/login_scanner/smh.rb
@@ -33,11 +33,7 @@ module Metasploit
           res = nil
 
           begin
-            cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies, http_username, http_password)
-            configure_http_client(cli)
-            cli.connect
-            req = cli.request_cgi(req_opts)
-            res = cli.send_recv(req)
+            res = send_request(req)
 
           rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, ::EOFError, ::Timeout::Error => e
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)

--- a/lib/metasploit/framework/login_scanner/wordpress_multicall.rb
+++ b/lib/metasploit/framework/login_scanner/wordpress_multicall.rb
@@ -92,10 +92,7 @@ module Metasploit
               'ctype'   =>'text/xml'
             }
 
-          client = Rex::Proto::Http::Client.new(host, port, {}, ssl, ssl_version, proxies, http_username, http_password)
-          client.connect
-          req  = client.request_cgi(opts)
-          res  = client.send_recv(req)
+          res  = send_request(opts)
 
           if res && res.code != 200
             sleep(block_wait * 60)

--- a/lib/metasploit/framework/login_scanner/wordpress_rpc.rb
+++ b/lib/metasploit/framework/login_scanner/wordpress_rpc.rb
@@ -23,10 +23,12 @@ module Metasploit
 
           begin
 
-            response = send_request({
+            response = send_request(
+              {
                 'uri' => uri,
                 'method' => method,
-                'data' => generate_xml_request(credential.public,credential.private})
+                'data' => generate_xml_request(credential.public,credential.private)
+              }
             )
 
             if response && response.code == 200 && response.body =~ /<value><int>401<\/int><\/value>/ || response.body =~ /<name>user_id<\/name>/

--- a/lib/metasploit/framework/login_scanner/wordpress_rpc.rb
+++ b/lib/metasploit/framework/login_scanner/wordpress_rpc.rb
@@ -9,11 +9,6 @@ module Metasploit
 
         # (see Base#attempt_login)
         def attempt_login(credential)
-          http_client = Rex::Proto::Http::Client.new(
-              host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies, http_username, http_password
-          )
-          configure_http_client(http_client)
-
           result_opts = {
               credential: credential,
               host: host,
@@ -27,14 +22,12 @@ module Metasploit
           end
 
           begin
-            http_client.connect
 
-            request = http_client.request_cgi(
+            response = send_request({
                 'uri' => uri,
                 'method' => method,
-                'data' => generate_xml_request(credential.public,credential.private)
+                'data' => generate_xml_request(credential.public,credential.private})
             )
-            response = http_client.send_recv(request)
 
             if response && response.code == 200 && response.body =~ /<value><int>401<\/int><\/value>/ || response.body =~ /<name>user_id<\/name>/
               result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: response)

--- a/lib/metasploit/framework/login_scanner/zabbix.rb
+++ b/lib/metasploit/framework/login_scanner/zabbix.rb
@@ -41,7 +41,10 @@ module Metasploit
         # (see Base#check_setup)
         def check_setup
           begin
-            res = pass_request({'uri' => normalize_uri('/')})
+            res = pass_request({
+              'uri' => normalize_uri('/'),
+              'requestcgi' => false
+            })
             return "Connection failed" if res.nil?
 
             if res.code != 200
@@ -97,7 +100,8 @@ module Metasploit
             'data'    => data,
             'headers' => {
               'Content-Type'   => 'application/x-www-form-urlencoded'
-            }
+            },
+            'requestcgi' => false
           }
 
           pass_request(opts)
@@ -110,7 +114,8 @@ module Metasploit
             'method'  => 'GET',
             'headers' => {
               'Cookie'  => "#{self.zsession}"
-            }
+            },
+            'requestcgi' => false
           }
           pass_request(opts)
         end

--- a/lib/metasploit/framework/login_scanner/zabbix.rb
+++ b/lib/metasploit/framework/login_scanner/zabbix.rb
@@ -41,7 +41,7 @@ module Metasploit
         # (see Base#check_setup)
         def check_setup
           begin
-            res = pass_request({
+            res = send_request_and_grab_cookie({
               'uri' => normalize_uri('/'),
               'requestcgi' => false
             })
@@ -71,7 +71,7 @@ module Metasploit
         #
         # @param (see Rex::Proto::Http::Resquest#request_raw)
         # @return [Rex::Proto::Http::Response] The HTTP response
-        def pass_request(opts)
+        def send_request_and_grab_cookie(opts)
           res = send_request(opts)
 
           # Found a cookie? Set it. We're going to need it.
@@ -104,7 +104,7 @@ module Metasploit
             'requestcgi' => false
           }
 
-          pass_request(opts)
+          send_request_and_grab_cookie(opts)
         end
 
 
@@ -117,7 +117,7 @@ module Metasploit
             },
             'requestcgi' => false
           }
-          pass_request(opts)
+          send_request_and_grab_cookie(opts)
         end
 
         # Tries to login to Zabbix

--- a/lib/metasploit/framework/login_scanner/zabbix.rb
+++ b/lib/metasploit/framework/login_scanner/zabbix.rb
@@ -41,7 +41,7 @@ module Metasploit
         # (see Base#check_setup)
         def check_setup
           begin
-            res = send_request({'uri' => normalize_uri('/')})
+            res = pass_request({'uri' => normalize_uri('/')})
             return "Connection failed" if res.nil?
 
             if res.code != 200
@@ -68,12 +68,8 @@ module Metasploit
         #
         # @param (see Rex::Proto::Http::Resquest#request_raw)
         # @return [Rex::Proto::Http::Response] The HTTP response
-        def send_request(opts)
-          cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => self}, ssl, ssl_version, proxies, http_username, http_password)
-          configure_http_client(cli)
-          cli.connect
-          req = cli.request_raw(opts)
-          res = cli.send_recv(req)
+        def pass_request(opts)
+          res = send_request(opts)
 
           # Found a cookie? Set it. We're going to need it.
           if res && res.get_cookies =~ /(zbx_session(?:id)?=\w+(?:%3D){0,2};)/i
@@ -104,7 +100,7 @@ module Metasploit
             }
           }
 
-          send_request(opts)
+          pass_request(opts)
         end
 
 
@@ -116,7 +112,7 @@ module Metasploit
               'Cookie'  => "#{self.zsession}"
             }
           }
-          send_request(opts)
+          pass_request(opts)
         end
 
         # Tries to login to Zabbix

--- a/spec/lib/metasploit/framework/login_scanner/chef_webui_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/chef_webui_spec.rb
@@ -46,20 +46,20 @@ RSpec.describe Metasploit::Framework::LoginScanner::ChefWebUI do
     200
   end
 
-  context '#pass_request' do
+  context '#send_request_and_grab_cookie' do
     let(:req_opts) do
       {'uri'=>'/users/sign_in', 'method'=>'GET'}
     end
 
     it 'returns a Rex::Proto::Http::Response object' do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).and_return(Rex::Proto::Http::Response.new(res_code))
-      expect(http_scanner.pass_request(req_opts)).to be_kind_of(Rex::Proto::Http::Response)
+      expect(http_scanner.send_request_and_grab_cookie(req_opts)).to be_kind_of(Rex::Proto::Http::Response)
     end
 
     it 'parses session cookies' do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).and_return(Rex::Proto::Http::Response.new(res_code))
       allow_any_instance_of(Rex::Proto::Http::Response).to receive(:get_cookies).and_return("_sandbox_session=c2g2ZXVhZWRpU1RMTDg1SmkyS0pQVnUwYUFCcDZJYklwb2gyYmhZd2dvcGI3b2VSaWd6L0Q4SkVOaytKa1VPNmd0R01HRHFabnFZZ09YUVZhVHFPWnhRdkZTSHF6VnpCU1Y3VFRRcTEyV0xVTUtLNlZIK3VBM3V2ZlFTS2FaOWV3cjlPT2RLRlZIeG1UTElMY3ozUEtIOFNzWkFDbW9VQ1VpRlF6ZThiNXZHbmVudWY0Nk9PSSsxSFg2WVZjeklvLS1UTk1GU2x6QXJFR3lFSjNZL0JhYzBRPT0%3D--6f0cc3051739c8a95551339c3f2a084e0c30924e")
-      http_scanner.pass_request(req_opts)
+      http_scanner.send_request_and_grab_cookie(req_opts)
       expect(http_scanner.session_name).to eq("_sandbox_session")
       expect(http_scanner.session_id).to eq("c2g2ZXVhZWRpU1RMTDg1SmkyS0pQVnUwYUFCcDZJYklwb2gyYmhZd2dvcGI3b2VSaWd6L0Q4SkVOaytKa1VPNmd0R01HRHFabnFZZ09YUVZhVHFPWnhRdkZTSHF6VnpCU1Y3VFRRcTEyV0xVTUtLNlZIK3VBM3V2ZlFTS2FaOWV3cjlPT2RLRlZIeG1UTElMY3ozUEtIOFNzWkFDbW9VQ1VpRlF6ZThiNXZHbmVudWY0Nk9PSSsxSFg2WVZjeklvLS1UTk1GU2x6QXJFR3lFSjNZL0JhYzBRPT0%3D--6f0cc3051739c8a95551339c3f2a084e0c30924e")
     end
@@ -67,12 +67,12 @@ RSpec.describe Metasploit::Framework::LoginScanner::ChefWebUI do
 
   context '#try_credential' do
     it 'sends a login request to /users/login_exec' do
-      expect(http_scanner).to receive(:pass_request).with(hash_including('uri'=>'/users/login_exec'))
+      expect(http_scanner).to receive(:send_request_and_grab_cookie).with(hash_including('uri'=>'/users/login_exec'))
       http_scanner.try_credential('byV12YkMA6NV3zJFqclZjy1JR+AZYbCx75gT0dipoAo=', cred)
     end
 
     it 'sends a login request containing the username and password' do
-      expect(http_scanner).to receive(:pass_request).with(hash_including('data'=>"utf8=%E2%9C%93&authenticity_token=byV12YkMA6NV3zJFqclZjy1JR%2bAZYbCx75gT0dipoAo%3d&name=#{username}&password=#{password}&commit=login"))
+      expect(http_scanner).to receive(:send_request_and_grab_cookie).with(hash_including('data'=>"utf8=%E2%9C%93&authenticity_token=byV12YkMA6NV3zJFqclZjy1JR%2bAZYbCx75gT0dipoAo%3d&name=#{username}&password=#{password}&commit=login"))
       http_scanner.try_credential('byV12YkMA6NV3zJFqclZjy1JR+AZYbCx75gT0dipoAo=', cred)
     end
   end

--- a/spec/lib/metasploit/framework/login_scanner/chef_webui_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/chef_webui_spec.rb
@@ -46,20 +46,20 @@ RSpec.describe Metasploit::Framework::LoginScanner::ChefWebUI do
     200
   end
 
-  context '#send_request' do
+  context '#pass_request' do
     let(:req_opts) do
       {'uri'=>'/users/sign_in', 'method'=>'GET'}
     end
 
     it 'returns a Rex::Proto::Http::Response object' do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).and_return(Rex::Proto::Http::Response.new(res_code))
-      expect(http_scanner.send_request(req_opts)).to be_kind_of(Rex::Proto::Http::Response)
+      expect(http_scanner.pass_request(req_opts)).to be_kind_of(Rex::Proto::Http::Response)
     end
 
     it 'parses session cookies' do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).and_return(Rex::Proto::Http::Response.new(res_code))
       allow_any_instance_of(Rex::Proto::Http::Response).to receive(:get_cookies).and_return("_sandbox_session=c2g2ZXVhZWRpU1RMTDg1SmkyS0pQVnUwYUFCcDZJYklwb2gyYmhZd2dvcGI3b2VSaWd6L0Q4SkVOaytKa1VPNmd0R01HRHFabnFZZ09YUVZhVHFPWnhRdkZTSHF6VnpCU1Y3VFRRcTEyV0xVTUtLNlZIK3VBM3V2ZlFTS2FaOWV3cjlPT2RLRlZIeG1UTElMY3ozUEtIOFNzWkFDbW9VQ1VpRlF6ZThiNXZHbmVudWY0Nk9PSSsxSFg2WVZjeklvLS1UTk1GU2x6QXJFR3lFSjNZL0JhYzBRPT0%3D--6f0cc3051739c8a95551339c3f2a084e0c30924e")
-      http_scanner.send_request(req_opts)
+      http_scanner.pass_request(req_opts)
       expect(http_scanner.session_name).to eq("_sandbox_session")
       expect(http_scanner.session_id).to eq("c2g2ZXVhZWRpU1RMTDg1SmkyS0pQVnUwYUFCcDZJYklwb2gyYmhZd2dvcGI3b2VSaWd6L0Q4SkVOaytKa1VPNmd0R01HRHFabnFZZ09YUVZhVHFPWnhRdkZTSHF6VnpCU1Y3VFRRcTEyV0xVTUtLNlZIK3VBM3V2ZlFTS2FaOWV3cjlPT2RLRlZIeG1UTElMY3ozUEtIOFNzWkFDbW9VQ1VpRlF6ZThiNXZHbmVudWY0Nk9PSSsxSFg2WVZjeklvLS1UTk1GU2x6QXJFR3lFSjNZL0JhYzBRPT0%3D--6f0cc3051739c8a95551339c3f2a084e0c30924e")
     end
@@ -67,12 +67,12 @@ RSpec.describe Metasploit::Framework::LoginScanner::ChefWebUI do
 
   context '#try_credential' do
     it 'sends a login request to /users/login_exec' do
-      expect(http_scanner).to receive(:send_request).with(hash_including('uri'=>'/users/login_exec'))
+      expect(http_scanner).to receive(:pass_request).with(hash_including('uri'=>'/users/login_exec'))
       http_scanner.try_credential('byV12YkMA6NV3zJFqclZjy1JR+AZYbCx75gT0dipoAo=', cred)
     end
 
     it 'sends a login request containing the username and password' do
-      expect(http_scanner).to receive(:send_request).with(hash_including('data'=>"utf8=%E2%9C%93&authenticity_token=byV12YkMA6NV3zJFqclZjy1JR%2bAZYbCx75gT0dipoAo%3d&name=#{username}&password=#{password}&commit=login"))
+      expect(http_scanner).to receive(:pass_request).with(hash_including('data'=>"utf8=%E2%9C%93&authenticity_token=byV12YkMA6NV3zJFqclZjy1JR%2bAZYbCx75gT0dipoAo%3d&name=#{username}&password=#{password}&commit=login"))
       http_scanner.try_credential('byV12YkMA6NV3zJFqclZjy1JR+AZYbCx75gT0dipoAo=', cred)
     end
   end

--- a/spec/lib/metasploit/framework/login_scanner/glassfish_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/glassfish_spec.rb
@@ -66,20 +66,20 @@ RSpec.describe Metasploit::Framework::LoginScanner::Glassfish do
     http_scanner.instance_variable_set(:@version, good_version)
   end
 
-  context '#pass_request' do
+  context '#send_request_and_grab_cookie' do
     let(:req_opts) do
       {'uri'=>'/', 'method'=>'GET'}
     end
 
     it 'returns a Rex::Proto::Http::Response object' do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).and_return(Rex::Proto::Http::Response.new(res_code))
-      expect(http_scanner.pass_request(req_opts)).to be_kind_of(Rex::Proto::Http::Response)
+      expect(http_scanner.send_request_and_grab_cookie(req_opts)).to be_kind_of(Rex::Proto::Http::Response)
     end
 
     it 'parses JSESSIONID session cookies' do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).and_return(Rex::Proto::Http::Response.new(res_code))
       allow_any_instance_of(Rex::Proto::Http::Response).to receive(:get_cookies).and_return("JSESSIONID=JSESSIONID_MAGIC_VALUE;")
-      http_scanner.pass_request(req_opts)
+      http_scanner.send_request_and_grab_cookie(req_opts)
       expect(http_scanner.jsession).to eq("JSESSIONID_MAGIC_VALUE")
     end
   end
@@ -102,12 +102,12 @@ RSpec.describe Metasploit::Framework::LoginScanner::Glassfish do
 
   context '#try_login' do
     it 'sends a login request to /j_security_check' do
-      expect(http_scanner).to receive(:pass_request).with(hash_including('uri'=>'/j_security_check'))
+      expect(http_scanner).to receive(:send_request_and_grab_cookie).with(hash_including('uri'=>'/j_security_check'))
       http_scanner.try_login(cred)
     end
 
     it 'sends a login request containing the username and password' do
-      expect(http_scanner).to receive(:pass_request).with(hash_including('data'=>"j_username=#{username}&j_password=#{password}&loginButton=Login"))
+      expect(http_scanner).to receive(:send_request_and_grab_cookie).with(hash_including('data'=>"j_username=#{username}&j_password=#{password}&loginButton=Login"))
       http_scanner.try_login(cred)
     end
   end

--- a/spec/lib/metasploit/framework/login_scanner/glassfish_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/glassfish_spec.rb
@@ -66,20 +66,20 @@ RSpec.describe Metasploit::Framework::LoginScanner::Glassfish do
     http_scanner.instance_variable_set(:@version, good_version)
   end
 
-  context '#send_request' do
+  context '#pass_request' do
     let(:req_opts) do
       {'uri'=>'/', 'method'=>'GET'}
     end
 
     it 'returns a Rex::Proto::Http::Response object' do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).and_return(Rex::Proto::Http::Response.new(res_code))
-      expect(http_scanner.send_request(req_opts)).to be_kind_of(Rex::Proto::Http::Response)
+      expect(http_scanner.pass_request(req_opts)).to be_kind_of(Rex::Proto::Http::Response)
     end
 
     it 'parses JSESSIONID session cookies' do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).and_return(Rex::Proto::Http::Response.new(res_code))
       allow_any_instance_of(Rex::Proto::Http::Response).to receive(:get_cookies).and_return("JSESSIONID=JSESSIONID_MAGIC_VALUE;")
-      http_scanner.send_request(req_opts)
+      http_scanner.pass_request(req_opts)
       expect(http_scanner.jsession).to eq("JSESSIONID_MAGIC_VALUE")
     end
   end
@@ -102,12 +102,12 @@ RSpec.describe Metasploit::Framework::LoginScanner::Glassfish do
 
   context '#try_login' do
     it 'sends a login request to /j_security_check' do
-      expect(http_scanner).to receive(:send_request).with(hash_including('uri'=>'/j_security_check'))
+      expect(http_scanner).to receive(:pass_request).with(hash_including('uri'=>'/j_security_check'))
       http_scanner.try_login(cred)
     end
 
     it 'sends a login request containing the username and password' do
-      expect(http_scanner).to receive(:send_request).with(hash_including('data'=>"j_username=#{username}&j_password=#{password}&loginButton=Login"))
+      expect(http_scanner).to receive(:pass_request).with(hash_including('data'=>"j_username=#{username}&j_password=#{password}&loginButton=Login"))
       http_scanner.try_login(cred)
     end
   end

--- a/spec/lib/metasploit/framework/login_scanner/zabbix_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/zabbix_spec.rb
@@ -66,32 +66,32 @@ RSpec.describe Metasploit::Framework::LoginScanner::Zabbix do
     http_scanner.instance_variable_set(:@version, good_version)
   end
 
-  context '#pass_request' do
+  context '#send_request_and_grab_cookie' do
     let(:req_opts) do
       {'uri'=>'/', 'method'=>'GET'}
     end
 
     it 'returns a Rex::Proto::Http::Response object' do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).and_return(Rex::Proto::Http::Response.new(res_code))
-      expect(http_scanner.pass_request(req_opts)).to be_kind_of(Rex::Proto::Http::Response)
+      expect(http_scanner.send_request_and_grab_cookie(req_opts)).to be_kind_of(Rex::Proto::Http::Response)
     end
 
     it 'parses zbx_sessionid session cookies' do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).and_return(Rex::Proto::Http::Response.new(res_code))
       allow_any_instance_of(Rex::Proto::Http::Response).to receive(:get_cookies).and_return("zbx_sessionid=ZBXSESSIONID_MAGIC_VALUE;")
-      http_scanner.pass_request(req_opts)
+      http_scanner.send_request_and_grab_cookie(req_opts)
       expect(http_scanner.zsession).to match(/zbx_session(?:id)?=ZBXSESSIONID_MAGIC_VALUE/)
     end
   end
 
   context '#try_credential' do
     it 'sends a login request to /index.php' do
-      expect(http_scanner).to receive(:pass_request).with(hash_including('uri'=>'/index.php'))
+      expect(http_scanner).to receive(:send_request_and_grab_cookie).with(hash_including('uri'=>'/index.php'))
       http_scanner.try_credential(cred)
     end
 
     it 'sends a login request containing the username and password' do
-      expect(http_scanner).to receive(:pass_request).with(hash_including('data'=>"request=&name=#{username}&password=#{password}&autologin=1&enter=Sign%20in"))
+      expect(http_scanner).to receive(:send_request_and_grab_cookie).with(hash_including('data'=>"request=&name=#{username}&password=#{password}&autologin=1&enter=Sign%20in"))
       http_scanner.try_credential(cred)
     end
   end

--- a/spec/lib/metasploit/framework/login_scanner/zabbix_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/zabbix_spec.rb
@@ -66,32 +66,32 @@ RSpec.describe Metasploit::Framework::LoginScanner::Zabbix do
     http_scanner.instance_variable_set(:@version, good_version)
   end
 
-  context '#send_request' do
+  context '#pass_request' do
     let(:req_opts) do
       {'uri'=>'/', 'method'=>'GET'}
     end
 
     it 'returns a Rex::Proto::Http::Response object' do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).and_return(Rex::Proto::Http::Response.new(res_code))
-      expect(http_scanner.send_request(req_opts)).to be_kind_of(Rex::Proto::Http::Response)
+      expect(http_scanner.pass_request(req_opts)).to be_kind_of(Rex::Proto::Http::Response)
     end
 
     it 'parses zbx_sessionid session cookies' do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).and_return(Rex::Proto::Http::Response.new(res_code))
       allow_any_instance_of(Rex::Proto::Http::Response).to receive(:get_cookies).and_return("zbx_sessionid=ZBXSESSIONID_MAGIC_VALUE;")
-      http_scanner.send_request(req_opts)
+      http_scanner.pass_request(req_opts)
       expect(http_scanner.zsession).to match(/zbx_session(?:id)?=ZBXSESSIONID_MAGIC_VALUE/)
     end
   end
 
   context '#try_credential' do
     it 'sends a login request to /index.php' do
-      expect(http_scanner).to receive(:send_request).with(hash_including('uri'=>'/index.php'))
+      expect(http_scanner).to receive(:pass_request).with(hash_including('uri'=>'/index.php'))
       http_scanner.try_credential(cred)
     end
 
     it 'sends a login request containing the username and password' do
-      expect(http_scanner).to receive(:send_request).with(hash_including('data'=>"request=&name=#{username}&password=#{password}&autologin=1&enter=Sign%20in"))
+      expect(http_scanner).to receive(:pass_request).with(hash_including('data'=>"request=&name=#{username}&password=#{password}&autologin=1&enter=Sign%20in"))
       http_scanner.try_credential(cred)
     end
   end


### PR DESCRIPTION
This PR reconstructs every type-2 login scanner library into type-1 login scanner library.  
  
All login scanner modules craft a custom HTTP request for authenticating to the server. In order to transmit these HTTP requests to the server, the login scanner library needs to make an instance of the **Rex::Proto::Http::Client** class. To follow a common template for all login scanners, the `send_request()` method was created in **Metasploit::Framework::LoginScanner::HTTP** which instantiates an object of **Rex::Proto::Http::Client** and transmits the HTTP request. 
    
There are 2 types of login scanners in the library, categorized on the way they instantiate an object of the Rex::Proto::Http::Client class :
**Type-1:** Which access the Rex::Proto::Http::Client through **`Metasploit::Framework::LoginScanner::HTTP#send_request()`** to send requests/responses (Ideal method). E.g. - [advantech_webaccess lib](https://github.com/rapid7/metasploit-framework/blob/master/lib/metasploit/framework/login_scanner/caidao.rb#L56-L62), [cisco_firepower lib](https://github.com/rapid7/metasploit-framework/blob/master/lib/metasploit/framework/login_scanner/cisco_firepower.rb#L31-L39) etc.
**Type-2:** Which access the Rex::Proto::Http::Client independently of **`Metasploit::Framework::LoginScanner:: HTTP#send_request()`** to send requests/responses. E.g. - [buffalo lib](https://github.com/rapid7/metasploit-framework/blob/master/lib/metasploit/framework/login_scanner/buffalo.rb#L36-L48), [gitlab lib](https://github.com/rapid7/metasploit-framework/blob/master/lib/metasploit/framework/login_scanner/gitlab.rb#L30-L42).

In order to make HTTP-Trace accessible by every login scanner, type-2 login scanners need to be converted into type-1 login scanners. This is because the proc required for HTTP-Tracing is implemented in the **`Metasploit::Framework::LoginScanner::HTTP#send_request()`** API (by #4 ). 