### PR TITLE
Add spec tests for HTTP-Trace 

### DIFF
--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -325,9 +325,14 @@ module Metasploit
         end
 
 
-        # This method returns a proc to log HTTP requests and responses
-        # if datastore['HttpTrace'] is set.
+        # Defines a proc to log HTTP requests and responses
+        #
+        # @param http_trace [Bool] A Boolean representing the datastore['HttpTrace']
+        # to check if HttpTrace is set or unset.
+        #
+        # @return [Proc] A Proc object to log HTTP requests and responses
         def set_http_trace_proc(http_trace)
+          proc_httptrace = nil
           if http_trace
             proc_httptrace = proc { |request, response|
               request_color, response_color =

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -339,9 +339,6 @@ module Metasploit
               request_color, response_color =
                 (http_trace_colors || 'red/blu').split('/').map { |color| "%bld%#{color}" }
               
-              #request = request.to_s(headers_only: http_trace_headers_only)
-
-              #require 'pry';binding.pry
               framework_module.print_line('#' * 20)
               framework_module.print_line('# Request:')
               framework_module.print_line('#' * 20)
@@ -352,7 +349,6 @@ module Metasploit
               framework_module.print_line('#' * 20)
               
               if response
-                #require 'pry';binding.pry
                 response = response.to_terminal_output(headers_only: http_trace_headers_only)
 
                 framework_module.print_line("%clr#{response_color}#{response}%clr")

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -246,32 +246,8 @@ module Metasploit
           context         = opts['context'] || { 'Msf' => framework, 'MsfExploit' => framework_module}
 
           res = nil
+          http_trace_proc = set_http_trace_proc(http_trace)
           
-          if http_trace
-            proc_httptrace = proc { |request, response|
-              request_color, response_color =
-                (http_trace_colors || 'red/blu').split('/').map { |color| "%bld%#{color}" }
-              
-              request = request.to_s(headers_only: http_trace_headers_only)
-              print_line('#' * 20)
-              print_line('# Request:')
-              print_line('#' * 20)
-              print_line("%clr#{request_color}#{request}%clr")
-              
-              print_line('#' * 20)
-              print_line('# Response:')
-              print_line('#' * 20)
-              
-              if response
-                response = response.to_terminal_output(headers_only: http_trace_headers_only)
-                print_line("%clr#{response_color}#{response}%clr")
-              else
-                print_line('No response received')
-              end
-            }
-          end
-
-
           cli = Rex::Proto::Http::Client.new(
             rhost,
             rport,
@@ -281,7 +257,7 @@ module Metasploit
             cli_proxies,
             username,
             password,
-            http_trace_proc: proc_httptrace
+            http_trace_proc: http_trace_proc
           )
           configure_http_client(cli)
 
@@ -347,6 +323,38 @@ module Metasploit
 
           Result.new(result_opts)
         end
+
+
+        # This method returns a proc to log HTTP requests and responses
+        # if datastore['HttpTrace'] is set.
+        def set_http_trace_proc(http_trace)
+          if http_trace
+            proc_httptrace = proc { |request, response|
+              request_color, response_color =
+                (http_trace_colors || 'red/blu').split('/').map { |color| "%bld%#{color}" }
+              
+              request = request.to_s(headers_only: http_trace_headers_only)
+              print_line('#' * 20)
+              print_line('# Request:')
+              print_line('#' * 20)
+              print_line("%clr#{request_color}#{request}%clr")
+              
+              print_line('#' * 20)
+              print_line('# Response:')
+              print_line('#' * 20)
+              
+              if response
+                response = response.to_terminal_output(headers_only: http_trace_headers_only)
+                print_line("%clr#{response_color}#{response}%clr")
+              else
+                print_line('No response received')
+              end
+            }
+          end
+
+          proc_httptrace
+        end
+
 
         private
 

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -337,7 +337,7 @@ module Metasploit
           if http_trace
             proc_httptrace = proc { |request, response|
               request_color, response_color =
-                (http_trace_colors || 'red/blu').split('/').map { |color| "%bld%#{color}" }
+                (http_trace_colors || 'red/blu').split('/').map { |color| color.blank? ? "" : "%bld%#{color}" }
               
               framework_module.print_line('#' * 20)
               framework_module.print_line('# Request:')

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -339,9 +339,9 @@ module Metasploit
               request_color, response_color =
                 (http_trace_colors || 'red/blu').split('/').map { |color| "%bld%#{color}" }
               
-              #require 'pry';binding.pry
               #request = request.to_s(headers_only: http_trace_headers_only)
 
+              #require 'pry';binding.pry
               framework_module.print_line('#' * 20)
               framework_module.print_line('# Request:')
               framework_module.print_line('#' * 20)

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -331,7 +331,7 @@ module Metasploit
         # @param http_trace [Bool] A Boolean representing the datastore['HttpTrace']
         # to check if HttpTrace is set or unset.
         #
-        # @return [Proc] A Proc object to log HTTP requests and responses
+        # @return [Proc] A Proc object to log HTTP requests and responses, or nil if the datastore['HttpTrace'] is unset
         def set_http_trace_proc(http_trace, http_trace_headers_only, http_trace_colors)
           proc_httptrace = nil
           if http_trace

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -328,9 +328,9 @@ module Metasploit
 
         # Defines a proc to log HTTP requests and responses
         #
-        # @param http_trace [Bool] A Boolean representing the datastore['HttpTrace']
-        # to check if HttpTrace is set or unset.
-        #
+        # @param http_trace [Bool] A Boolean representing the datastore['HttpTrace'] to check if HttpTrace is set or unset.
+        # @param http_trace_headers_only [Bool] A Boolean representing the datastore['HttpTraceHeadersOnly'] to check if only HTTP headers need to be logged.
+        # @param http_trace_colors [String] A string representing the datastore['HttpTraceColors'] to specify the colors in which request and response need to be logged.
         # @return [Proc] A Proc object to log HTTP requests and responses, or nil if the datastore['HttpTrace'] is unset
         def set_http_trace_proc(http_trace, http_trace_headers_only, http_trace_colors)
           proc_httptrace = nil
@@ -339,6 +339,8 @@ module Metasploit
               request_color, response_color =
                 (http_trace_colors || 'red/blu').split('/').map { |color| color.blank? ? "" : "%bld%#{color}" }
               
+              #require 'pry';binding.pry
+              request = request.to_s(headers_only: http_trace_headers_only)
               framework_module.print_line('#' * 20)
               framework_module.print_line('# Request:')
               framework_module.print_line('#' * 20)

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -339,11 +339,8 @@ module Metasploit
               request_color, response_color =
                 (http_trace_colors || 'red/blu').split('/').map { |color| "%bld%#{color}" }
               
-              if http_trace_headers_only
-                request = request.to_s(headers_only: http_trace_headers_only)
-              else
-                request = request.to_s()
-              end
+              request = request.to_s()
+
               print_line('#' * 20)
               print_line('# Request:')
               print_line('#' * 20)
@@ -354,11 +351,8 @@ module Metasploit
               print_line('#' * 20)
               
               if response
-                if http_trace_headers_only
-                  response = response.to_terminal_output(headers_only: http_trace_headers_only)
-                else
-                  response = response.to_terminal_output()
-                end
+                response = response.to_terminal_output(headers_only: http_trace_headers_only)
+
                 print_line("%clr#{response_color}#{response}%clr")
               else
                 print_line('No response received')

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -340,7 +340,7 @@ module Metasploit
                 (http_trace_colors || 'red/blu').split('/').map { |color| "%bld%#{color}" }
               
               if http_trace_headers_only
-                request = request.to_s(headers_only: http_trace_headers_only)
+                request = request.to_s(http_trace_headers_only)
               else
                 request = request.to_s()
               end
@@ -355,7 +355,7 @@ module Metasploit
               print_line('#' * 20)
               
               if response
-                response = response.to_terminal_output(headers_only: http_trace_headers_only)
+                response = response.to_terminal_output(http_trace_headers_only)
 
                 print_line("%clr#{response_color}#{response}%clr")
               else

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -339,7 +339,6 @@ module Metasploit
               request_color, response_color =
                 (http_trace_colors || 'red/blu').split('/').map { |color| color.blank? ? "" : "%bld%#{color}" }
               
-              #require 'pry';binding.pry
               request = request.to_s(headers_only: http_trace_headers_only)
               framework_module.print_line('#' * 20)
               framework_module.print_line('# Request:')

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -339,27 +339,25 @@ module Metasploit
               request_color, response_color =
                 (http_trace_colors || 'red/blu').split('/').map { |color| "%bld%#{color}" }
               
-              if http_trace_headers_only
-                request = request.to_s(http_trace_headers_only)
-              else
-                request = request.to_s()
-              end
+              #require 'pry';binding.pry
+              #request = request.to_s(headers_only: http_trace_headers_only)
 
-              print_line('#' * 20)
-              print_line('# Request:')
-              print_line('#' * 20)
-              print_line("%clr#{request_color}#{request}%clr")
+              framework_module.print_line('#' * 20)
+              framework_module.print_line('# Request:')
+              framework_module.print_line('#' * 20)
+              framework_module.print_line("%clr#{request_color}#{request}%clr")
               
-              print_line('#' * 20)
-              print_line('# Response:')
-              print_line('#' * 20)
+              framework_module.print_line('#' * 20)
+              framework_module.print_line('# Response:')
+              framework_module.print_line('#' * 20)
               
               if response
-                response = response.to_terminal_output(http_trace_headers_only)
+                #require 'pry';binding.pry
+                response = response.to_terminal_output(headers_only: http_trace_headers_only)
 
-                print_line("%clr#{response_color}#{response}%clr")
+                framework_module.print_line("%clr#{response_color}#{response}%clr")
               else
-                print_line('No response received')
+                framework_module.print_line('No response received')
               end
             }
           end

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -1,6 +1,5 @@
 require 'metasploit/framework/login_scanner/base'
 require 'metasploit/framework/login_scanner/rex_socket'
-require 'lib/msf/core/exploit/remote/http_client'
 require 'rex/ui/text/output/stdio'
 
 module Metasploit
@@ -334,9 +333,19 @@ module Metasploit
           proc_httptrace = nil
           if http_trace
             proc_httptrace = proc { |request, response|
-              http_trace_colors = '/' if http_trace_colors.empty?
+              http_trace_colors = 'red/blu' if http_trace_colors.blank? # Set the default colors if none were provided.
+              http_trace_colors += '/' if http_trace_colors.count('/') == 0 # Append "/"" to the end of the string if no "/" were found in the string to ensure consistent formatting.
+
+              # The following line will turn each "/" line into " / " to ensure we always get two elements on the following
+              # split operation, and then adds the appropriate bld tag to the color if one was provided before mapping that
+              # back into the final two element array that http_trace_colors will be set to.
+              #
+              # Final output should be something like this:
+              # >> "red/".gsub('/', ' / ').split('/').map { |color| color&.strip.blank? ? '' : "%bld#{color.strip}" }
+              # => ["%bldred", ""]
+              # >>
               request_color, response_color =
-                (http_trace_colors || 'red/blu').gsub('/', ' / ').split('/').map { |color| color&.strip!.blank? ? '' : "%bld#{color}" }
+                http_trace_colors.gsub('/', ' / ').split('/').map { |color| color&.strip.blank? ? '' : "%bld%#{color.strip}" }
 
               request = request.to_s(headers_only: http_trace_headers_only)
               framework_module.print_line('#' * 20)

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -339,7 +339,11 @@ module Metasploit
               request_color, response_color =
                 (http_trace_colors || 'red/blu').split('/').map { |color| "%bld%#{color}" }
               
-              request = request.to_s()
+              if http_trace_headers_only
+                request = request.to_s(headers_only: http_trace_headers_only)
+              else
+                request = request.to_s()
+              end
 
               print_line('#' * 20)
               print_line('# Request:')

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -150,30 +150,8 @@ module Exploit::Remote::HttpClient
 
     client_username = opts['username'] || datastore['HttpUsername'] || ''
     client_password = opts['password'] || datastore['HttpPassword'] || ''
-
-    if datastore['HttpTrace']
-      proc_httptrace = proc { |request, response| 
-        request_color, response_color = 
-          (datastore['HttpTraceColors'] || 'red/blu').split('/').map { |color| "%bld%#{color}" }
-        
-        request = request.to_s(headers_only: datastore['HttpTraceHeadersOnly'])
-        print_line('#' * 20)
-        print_line('# Request:')
-        print_line('#' * 20)
-        print_line("%clr#{request_color}#{request}%clr")
-
-        print_line('#' * 20)
-        print_line('# Response:')
-        print_line('#' * 20)
-        
-        if response
-          response = response.to_terminal_output(headers_only: datastore['HttpTraceHeadersOnly'])
-          print_line("%clr#{response_color}#{response}%clr")
-        else
-          print_line('No response received')
-        end
-      }
-    end
+    
+    http_trace_proc = set_http_trace_proc(datastore['HttpTrace'])
 
     nclient = Rex::Proto::Http::Client.new(
       opts['rhost'] || rhost,
@@ -188,7 +166,7 @@ module Exploit::Remote::HttpClient
       client_username,
       client_password,
       comm: opts['comm'],
-      http_trace_proc: proc_httptrace
+      http_trace_proc: http_trace_proc
     )
 
 
@@ -285,6 +263,38 @@ module Exploit::Remote::HttpClient
     socket = http_client.conn
     socket.extend(Rex::Proto::Http::WebSocket::Interface)
   end
+
+
+  # Returns a proc to log HTTP requests and responses
+  # if datastore['HttpTrace'] is set to true.
+  def set_http_trace_proc(http_trace)
+    if datastore['HttpTrace']
+      proc_httptrace = proc { |request, response| 
+        request_color, response_color = 
+          (datastore['HttpTraceColors'] || 'red/blu').split('/').map { |color| "%bld%#{color}" }
+        
+        request = request.to_s(headers_only: datastore['HttpTraceHeadersOnly'])
+        print_line('#' * 20)
+        print_line('# Request:')
+        print_line('#' * 20)
+        print_line("%clr#{request_color}#{request}%clr")
+
+        print_line('#' * 20)
+        print_line('# Response:')
+        print_line('#' * 20)
+        
+        if response
+          response = response.to_terminal_output(headers_only: datastore['HttpTraceHeadersOnly'])
+          print_line("%clr#{response_color}#{response}%clr")
+        else
+          print_line('No response received')
+        end
+      }
+    end
+
+   proc_httptrace 
+  end
+
 
   #
   # Converts datastore options into configuration parameters for the

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -151,7 +151,7 @@ module Exploit::Remote::HttpClient
     client_username = opts['username'] || datastore['HttpUsername'] || ''
     client_password = opts['password'] || datastore['HttpPassword'] || ''
     
-    http_trace_proc = set_http_trace_proc(datastore['HttpTrace'])
+    http_trace_proc = set_http_trace_proc(datastore['HttpTrace'], datastore['HttpTraceHeadersOnly'], datastore['HttpTraceColors'])
 
     nclient = Rex::Proto::Http::Client.new(
       opts['rhost'] || rhost,
@@ -264,20 +264,22 @@ module Exploit::Remote::HttpClient
     socket.extend(Rex::Proto::Http::WebSocket::Interface)
   end
   
+  
   # Defines a proc to log HTTP requests and responses
-  # 
-  # @param http_trace [Bool] A Boolean representing the datastore['HttpTrace']
-  # to check if HttpTrace is set or unset.
   #
-  # @return [Proc] A Proc object to log HTTP requests and responses, or nil if datastore['HttpTrace'] is unset
-  def set_http_trace_proc(http_trace)
+  # @param http_trace [Bool] A Boolean representing the datastore['HttpTrace'] to check if HttpTrace is set or unset.
+  # @param http_trace_headers_only [Bool] A Boolean representing the datastore['HttpTraceHeadersOnly'] to check if only HTTP headers need to be logged.
+  # @param http_trace_colors [String] A string representing the datastore['HttpTraceColors'] to specify the colors in which request and response need to be logged.
+  # @return [Proc] A Proc object to log HTTP requests and responses, or nil if the datastore['HttpTrace'] is unset
+  def set_http_trace_proc(http_trace, http_trace_headers_only, http_trace_colors)
     proc_httptrace = nil
     if http_trace
       proc_httptrace = proc { |request, response| 
         request_color, response_color = 
-          (datastore['HttpTraceColors'] || 'red/blu').split('/').map { |color| "%bld%#{color}" }
+          (http_trace_colors || 'red/blu').split('/').map { |color| color.blank? ? "" : "%bld%#{color}" }
         
-        request = request.to_s(headers_only: datastore['HttpTraceHeadersOnly'])
+        require 'pry';binding.pry
+        request = request.to_s(headers_only: http_trace_headers_only)
         print_line('#' * 20)
         print_line('# Request:')
         print_line('#' * 20)
@@ -288,7 +290,7 @@ module Exploit::Remote::HttpClient
         print_line('#' * 20)
         
         if response
-          response = response.to_terminal_output(headers_only: datastore['HttpTraceHeadersOnly'])
+          response = response.to_terminal_output(headers_only: http_trace_headers_only)
           print_line("%clr#{response_color}#{response}%clr")
         else
           print_line('No response received')

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -269,7 +269,7 @@ module Exploit::Remote::HttpClient
   # @param http_trace [Bool] A Boolean representing the datastore['HttpTrace']
   # to check if HttpTrace is set or unset.
   #
-  # @return [Proc] A Proc object to log HTTP requests and responses
+  # @return [Proc] A Proc object to log HTTP requests and responses, or nil if datastore['HttpTrace'] is unset
   def set_http_trace_proc(http_trace)
     proc_httptrace = nil
     if http_trace

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -263,12 +263,16 @@ module Exploit::Remote::HttpClient
     socket = http_client.conn
     socket.extend(Rex::Proto::Http::WebSocket::Interface)
   end
-
-
-  # Returns a proc to log HTTP requests and responses
-  # if datastore['HttpTrace'] is set to true.
+  
+  # Defines a proc to log HTTP requests and responses
+  # 
+  # @param http_trace [Bool] A Boolean representing the datastore['HttpTrace']
+  # to check if HttpTrace is set or unset.
+  #
+  # @return [Proc] A Proc object to log HTTP requests and responses
   def set_http_trace_proc(http_trace)
-    if datastore['HttpTrace']
+    proc_httptrace = nil
+    if http_trace
       proc_httptrace = proc { |request, response| 
         request_color, response_color = 
           (datastore['HttpTraceColors'] || 'red/blu').split('/').map { |color| "%bld%#{color}" }

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -278,7 +278,6 @@ module Exploit::Remote::HttpClient
         request_color, response_color = 
           (http_trace_colors || 'red/blu').split('/').map { |color| color.blank? ? "" : "%bld%#{color}" }
         
-        require 'pry';binding.pry
         request = request.to_s(headers_only: http_trace_headers_only)
         print_line('#' * 20)
         print_line('# Request:')

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -4,615 +4,605 @@ require 'uri'
 require 'digest'
 
 module Msf
-
-###
-#
-# This module provides methods for acting as an HTTP client when
-# exploiting an HTTP server.
-#
-###
-module Exploit::Remote::HttpClient
-
-  include Msf::Auxiliary::Report
-
+  ###
   #
-  # Initializes an exploit module that exploits a vulnerability in an HTTP
-  # server.
+  # This module provides methods for acting as an HTTP client when
+  # exploiting an HTTP server.
   #
-  def initialize(info = {})
-    super
+  ###
+  module Exploit::Remote::HttpClient
+    include Msf::Auxiliary::Report
 
-    register_options(
-      [
-        Opt::RHOST,
-        Opt::RPORT(80),
-        OptString.new('VHOST', [ false, "HTTP server virtual host" ]),
-        OptBool.new('SSL', [ false, 'Negotiate SSL/TLS for outgoing connections', false]),
-        Opt::Proxies
-      ], self.class
-    )
+    #
+    # Initializes an exploit module that exploits a vulnerability in an HTTP
+    # server.
+    #
+    def initialize(info = {})
+      super
 
-    register_advanced_options(
-      [
-        OptString.new('UserAgent', [false, 'The User-Agent header to use for all requests',
-          Rex::UserAgent.session_agent
+      register_options(
+        [
+          Opt::RHOST,
+          Opt::RPORT(80),
+          OptString.new('VHOST', [ false, 'HTTP server virtual host' ]),
+          OptBool.new('SSL', [ false, 'Negotiate SSL/TLS for outgoing connections', false]),
+          Opt::Proxies
+        ], self.class
+      )
+
+      register_advanced_options(
+        [
+          OptString.new('UserAgent', [
+            false, 'The User-Agent header to use for all requests',
+            Rex::UserAgent.session_agent
           ]),
-        OptString.new('HttpUsername', [false, 'The HTTP username to specify for authentication', '']),
-        OptString.new('HttpPassword', [false, 'The HTTP password to specify for authentication', '']),
-        OptPath.new('HttpRawHeaders', [false, 'Path to ERB-templatized raw headers to append to existing headers']),
-        OptBool.new('DigestAuthIIS', [false, 'Conform to IIS, should work for most servers. Only set to false for non-IIS servers', true]),
-        Opt::SSLVersion,
-        OptBool.new('FingerprintCheck', [ false, 'Conduct a pre-exploit fingerprint verification', true]),
-        OptString.new('DOMAIN', [ true, 'The domain to use for Windows authentication', 'WORKSTATION']),
-        OptFloat.new('HttpClientTimeout', [false, 'HTTP connection and receive timeout']),
-        OptBool.new('HttpTrace', [false, 'Show the raw HTTP requests and responses', false]),
-        OptBool.new('HttpTraceHeadersOnly', [false, 'Show HTTP headers only in HttpTrace', false]),
-        OptString.new('HttpTraceColors', [false, 'HTTP request and response colors for HttpTrace (unset to disable)', 'red/blu']),
-        OptString.new('SSLServerNameIndication', [ false, 'SSL/TLS Server Name Indication (SNI)', nil]),
-      ], self.class
-    )
+          OptString.new('HttpUsername', [false, 'The HTTP username to specify for authentication', '']),
+          OptString.new('HttpPassword', [false, 'The HTTP password to specify for authentication', '']),
+          OptPath.new('HttpRawHeaders', [false, 'Path to ERB-templatized raw headers to append to existing headers']),
+          OptBool.new('DigestAuthIIS', [false, 'Conform to IIS, should work for most servers. Only set to false for non-IIS servers', true]),
+          Opt::SSLVersion,
+          OptBool.new('FingerprintCheck', [ false, 'Conduct a pre-exploit fingerprint verification', true]),
+          OptString.new('DOMAIN', [ true, 'The domain to use for Windows authentication', 'WORKSTATION']),
+          OptFloat.new('HttpClientTimeout', [false, 'HTTP connection and receive timeout']),
+          OptBool.new('HttpTrace', [false, 'Show the raw HTTP requests and responses', false]),
+          OptBool.new('HttpTraceHeadersOnly', [false, 'Show HTTP headers only in HttpTrace', false]),
+          OptString.new('HttpTraceColors', [false, 'HTTP request and response colors for HttpTrace (unset to disable)', 'red/blu']),
+          OptString.new('SSLServerNameIndication', [ false, 'SSL/TLS Server Name Indication (SNI)', nil]),
+        ], self.class
+      )
 
-    register_evasion_options(
-      [
-        OptEnum.new('HTTP::uri_encode_mode', [false, 'Enable URI encoding', 'hex-normal', ['none', 'hex-normal', 'hex-noslashes', 'hex-random', 'hex-all', 'u-normal', 'u-all', 'u-random']]),
-        OptBool.new('HTTP::uri_full_url', [false, 'Use the full URL for all HTTP requests', false]),
-        OptInt.new('HTTP::pad_method_uri_count', [false, 'How many whitespace characters to use between the method and uri', 1]),
-        OptInt.new('HTTP::pad_uri_version_count', [false, 'How many whitespace characters to use between the uri and version', 1]),
-        OptEnum.new('HTTP::pad_method_uri_type', [false, 'What type of whitespace to use between the method and uri', 'space', ['space', 'tab', 'apache']]),
-        OptEnum.new('HTTP::pad_uri_version_type', [false, 'What type of whitespace to use between the uri and version', 'space', ['space', 'tab', 'apache']]),
-        OptBool.new('HTTP::method_random_valid', [false, 'Use a random, but valid, HTTP method for request', false]),
-        OptBool.new('HTTP::method_random_invalid', [false, 'Use a random invalid, HTTP method for request', false]),
-        OptBool.new('HTTP::method_random_case', [false, 'Use random casing for the HTTP method', false]),
-        OptBool.new('HTTP::version_random_valid', [false, 'Use a random, but valid, HTTP version for request', false]),
-        OptBool.new('HTTP::version_random_invalid', [false, 'Use a random invalid, HTTP version for request', false]),
-        OptBool.new('HTTP::uri_dir_self_reference', [false, 'Insert self-referential directories into the uri', false]),
-        OptBool.new('HTTP::uri_dir_fake_relative', [false, 'Insert fake relative directories into the uri', false]),
-        OptBool.new('HTTP::uri_use_backslashes', [false, 'Use back slashes instead of forward slashes in the uri ', false]),
-        OptBool.new('HTTP::pad_fake_headers', [false, 'Insert random, fake headers into the HTTP request', false]),
-        OptInt.new('HTTP::pad_fake_headers_count', [false, 'How many fake headers to insert into the HTTP request', 0]),
-        OptBool.new('HTTP::pad_get_params', [false, 'Insert random, fake query string variables into the request', false]),
-        OptInt.new('HTTP::pad_get_params_count', [false, 'How many fake query string variables to insert into the request', 16]),
-        OptBool.new('HTTP::pad_post_params', [false, 'Insert random, fake post variables into the request', false]),
-        OptInt.new('HTTP::pad_post_params_count', [false, 'How many fake post variables to insert into the request', 16]),
-        OptBool.new('HTTP::shuffle_get_params', [false, 'Randomize order of GET parameters', false]),
-        OptBool.new('HTTP::shuffle_post_params', [false, 'Randomize order of POST parameters', false]),
-        OptBool.new('HTTP::uri_fake_end', [false, 'Add a fake end of URI (eg: /%20HTTP/1.0/../../)', false]),
-        OptBool.new('HTTP::uri_fake_params_start', [false, 'Add a fake start of params to the URI (eg: /%3fa=b/../)', false]),
-        OptBool.new('HTTP::header_folding', [false, 'Enable folding of HTTP headers', false])
-#
-# Remaining evasions to implement
-#
-#        OptBool.new('HTTP::chunked', [false, 'Enable chunking of HTTP request via "Transfer-Encoding: chunked"', false]),
-#        OptInt.new('HTTP::junk_pipeline', [true, 'Insert the specified number of junk pipeline requests', 0]),
-      ], self.class
-    )
-    register_autofilter_ports([ 80, 8080, 443, 8000, 8888, 8880, 8008, 3000, 8443 ])
-    register_autofilter_services(%W{ http https })
+      register_evasion_options(
+        [
+          OptEnum.new('HTTP::uri_encode_mode', [false, 'Enable URI encoding', 'hex-normal', ['none', 'hex-normal', 'hex-noslashes', 'hex-random', 'hex-all', 'u-normal', 'u-all', 'u-random']]),
+          OptBool.new('HTTP::uri_full_url', [false, 'Use the full URL for all HTTP requests', false]),
+          OptInt.new('HTTP::pad_method_uri_count', [false, 'How many whitespace characters to use between the method and uri', 1]),
+          OptInt.new('HTTP::pad_uri_version_count', [false, 'How many whitespace characters to use between the uri and version', 1]),
+          OptEnum.new('HTTP::pad_method_uri_type', [false, 'What type of whitespace to use between the method and uri', 'space', ['space', 'tab', 'apache']]),
+          OptEnum.new('HTTP::pad_uri_version_type', [false, 'What type of whitespace to use between the uri and version', 'space', ['space', 'tab', 'apache']]),
+          OptBool.new('HTTP::method_random_valid', [false, 'Use a random, but valid, HTTP method for request', false]),
+          OptBool.new('HTTP::method_random_invalid', [false, 'Use a random invalid, HTTP method for request', false]),
+          OptBool.new('HTTP::method_random_case', [false, 'Use random casing for the HTTP method', false]),
+          OptBool.new('HTTP::version_random_valid', [false, 'Use a random, but valid, HTTP version for request', false]),
+          OptBool.new('HTTP::version_random_invalid', [false, 'Use a random invalid, HTTP version for request', false]),
+          OptBool.new('HTTP::uri_dir_self_reference', [false, 'Insert self-referential directories into the uri', false]),
+          OptBool.new('HTTP::uri_dir_fake_relative', [false, 'Insert fake relative directories into the uri', false]),
+          OptBool.new('HTTP::uri_use_backslashes', [false, 'Use back slashes instead of forward slashes in the uri ', false]),
+          OptBool.new('HTTP::pad_fake_headers', [false, 'Insert random, fake headers into the HTTP request', false]),
+          OptInt.new('HTTP::pad_fake_headers_count', [false, 'How many fake headers to insert into the HTTP request', 0]),
+          OptBool.new('HTTP::pad_get_params', [false, 'Insert random, fake query string variables into the request', false]),
+          OptInt.new('HTTP::pad_get_params_count', [false, 'How many fake query string variables to insert into the request', 16]),
+          OptBool.new('HTTP::pad_post_params', [false, 'Insert random, fake post variables into the request', false]),
+          OptInt.new('HTTP::pad_post_params_count', [false, 'How many fake post variables to insert into the request', 16]),
+          OptBool.new('HTTP::shuffle_get_params', [false, 'Randomize order of GET parameters', false]),
+          OptBool.new('HTTP::shuffle_post_params', [false, 'Randomize order of POST parameters', false]),
+          OptBool.new('HTTP::uri_fake_end', [false, 'Add a fake end of URI (eg: /%20HTTP/1.0/../../)', false]),
+          OptBool.new('HTTP::uri_fake_params_start', [false, 'Add a fake start of params to the URI (eg: /%3fa=b/../)', false]),
+          OptBool.new('HTTP::header_folding', [false, 'Enable folding of HTTP headers', false])
+          #
+          # Remaining evasions to implement
+          #
+          #        OptBool.new('HTTP::chunked', [false, 'Enable chunking of HTTP request via "Transfer-Encoding: chunked"', false]),
+          #        OptInt.new('HTTP::junk_pipeline', [true, 'Insert the specified number of junk pipeline requests', 0]),
+        ], self.class
+      )
+      register_autofilter_ports([ 80, 8080, 443, 8000, 8888, 8880, 8008, 3000, 8443 ])
+      register_autofilter_services(%w[http https])
 
-    # Initialize an empty cookie jar to keep cookies
-    self.cookie_jar = Msf::Exploit::Remote::HTTP::HttpCookieJar.new
-  end
+      # Initialize an empty cookie jar to keep cookies
+      self.cookie_jar = Msf::Exploit::Remote::HTTP::HttpCookieJar.new
+    end
 
-  def deregister_http_client_options
-    deregister_options('RHOST', 'RPORT', 'VHOST', 'SSL', 'SSLServerNameIndication', 'Proxies')
-  end
+    def deregister_http_client_options
+      deregister_options('RHOST', 'RPORT', 'VHOST', 'SSL', 'SSLServerNameIndication', 'Proxies')
+    end
 
-  #
-  # For HTTP Client exploits, we often want to verify that the server info matches some regex before
-  # firing a giant binary exploit blob at it. We override setup() here to accomplish that.
-  #
-  def setup
-    validate_fingerprint
-    super
-  end
+    #
+    # For HTTP Client exploits, we often want to verify that the server info matches some regex before
+    # firing a giant binary exploit blob at it. We override setup() here to accomplish that.
+    #
+    def setup
+      validate_fingerprint
+      super
+    end
 
-
-  # This method is meant to be overriden in the exploit module to specify a set of regexps to
-  # attempt to match against. A failure to match any of them results in a RuntimeError exception
-  # being raised.
-  #
-  def validate_fingerprint()
-    # Don't bother checking if there's no database active.
-    if (framework.db.active and
-        datastore['FingerprintCheck'] and
-        self.class.const_defined?('HttpFingerprint'))
-      # Get the module-specific config
-      opts = self.class.const_get('HttpFingerprint')
-      #
-      # XXX: Ideally we could have more structured matches, but doing that requires
-      # a more structured response cache.
-      #
-      info = http_fingerprint(opts)
-      if info and opts[:pattern]
-        opts[:pattern].each do |re|
-          if not re.match(info)
-            err = "The target server fingerprint \"#{info}\" does not match \"#{re.to_s}\", use 'set FingerprintCheck false' to disable this check."
-            fail_with(::Msf::Module::Failure::NotFound, err)
+    # This method is meant to be overriden in the exploit module to specify a set of regexps to
+    # attempt to match against. A failure to match any of them results in a RuntimeError exception
+    # being raised.
+    #
+    def validate_fingerprint
+      # Don't bother checking if there's no database active.
+      if (framework.db.active and
+          datastore['FingerprintCheck'] and
+          self.class.const_defined?('HttpFingerprint'))
+        # Get the module-specific config
+        opts = self.class.const_get('HttpFingerprint')
+        #
+        # XXX: Ideally we could have more structured matches, but doing that requires
+        # a more structured response cache.
+        #
+        info = http_fingerprint(opts)
+        if info and opts[:pattern]
+          opts[:pattern].each do |re|
+            if !re.match(info)
+              err = "The target server fingerprint \"#{info}\" does not match \"#{re}\", use 'set FingerprintCheck false' to disable this check."
+              fail_with(::Msf::Module::Failure::NotFound, err)
+            end
           end
+        elsif info.nil?
+          err = "The target server did not respond to fingerprinting, use 'set FingerprintCheck false' to disable this check."
+          fail_with(::Msf::Module::Failure::Unreachable, err)
         end
-      elsif info.nil?
-        err = "The target server did not respond to fingerprinting, use 'set FingerprintCheck false' to disable this check."
-        fail_with(::Msf::Module::Failure::Unreachable, err)
       end
     end
-  end
 
-  #
-  # Connects to an HTTP server.
-  #
-  def connect(opts={})
-    dossl = false
-    if(opts.has_key?('SSL'))
-      dossl = opts['SSL']
-    else
-      dossl = ssl
-    end
+    #
+    # Connects to an HTTP server.
+    #
+    def connect(opts = {})
+      dossl = false
+      if opts.has_key?('SSL')
+        dossl = opts['SSL']
+      else
+        dossl = ssl
+      end
 
-    client_username = opts['username'] || datastore['HttpUsername'] || ''
-    client_password = opts['password'] || datastore['HttpPassword'] || ''
-    
-    http_trace_proc = set_http_trace_proc(datastore['HttpTrace'], datastore['HttpTraceHeadersOnly'], datastore['HttpTraceColors'])
+      client_username = opts['username'] || datastore['HttpUsername'] || ''
+      client_password = opts['password'] || datastore['HttpPassword'] || ''
 
-    nclient = Rex::Proto::Http::Client.new(
-      opts['rhost'] || rhost,
-      (opts['rport'] || rport).to_i,
-      {
-        'Msf'        => framework,
-        'MsfExploit' => self,
-      },
-      dossl,
-      ssl_version,
-      proxies,
-      client_username,
-      client_password,
-      comm: opts['comm'],
-      http_trace_proc: http_trace_proc
-    )
+      http_trace_proc = set_http_trace_proc(http_trace, http_trace_headers_only, http_trace_colors)
 
+      nclient = Rex::Proto::Http::Client.new(
+        opts['rhost'] || rhost,
+        (opts['rport'] || rport).to_i,
+        {
+          'Msf' => framework,
+          'MsfExploit' => self
+        },
+        dossl,
+        ssl_version,
+        proxies,
+        client_username,
+        client_password,
+        comm: opts['comm'],
+        http_trace_proc: http_trace_proc
+      )
 
-    # Configure the HTTP client with the supplied parameter
-    vhost = opts['vhost'] || opts['rhost'] || self.vhost
-    nclient.set_config(
-      'vhost' => vhost,
-      'ssl_server_name_indication' => datastore['SSLServerNameIndication'] || vhost,
-      'agent' => datastore['UserAgent'],
-      'partial' => opts['partial'],
-      'uri_encode_mode'        => datastore['HTTP::uri_encode_mode'],
-      'uri_full_url'           => datastore['HTTP::uri_full_url'],
-      'pad_method_uri_count'   => datastore['HTTP::pad_method_uri_count'],
-      'pad_uri_version_count'  => datastore['HTTP::pad_uri_version_count'],
-      'pad_method_uri_type'    => datastore['HTTP::pad_method_uri_type'],
-      'pad_uri_version_type'   => datastore['HTTP::pad_uri_version_type'],
-      'method_random_valid'    => datastore['HTTP::method_random_valid'],
-      'method_random_invalid'  => datastore['HTTP::method_random_invalid'],
-      'method_random_case'     => datastore['HTTP::method_random_case'],
-      'version_random_valid'   => datastore['HTTP::version_random_valid'],
-      'version_random_invalid' => datastore['HTTP::version_random_invalid'],
-      'uri_dir_self_reference' => datastore['HTTP::uri_dir_self_reference'],
-      'uri_dir_fake_relative'  => datastore['HTTP::uri_dir_fake_relative'],
-      'uri_use_backslashes'    => datastore['HTTP::uri_use_backslashes'],
-      'pad_fake_headers'       => datastore['HTTP::pad_fake_headers'],
-      'pad_fake_headers_count' => datastore['HTTP::pad_fake_headers_count'],
-      'pad_get_params'         => datastore['HTTP::pad_get_params'],
-      'pad_get_params_count'   => datastore['HTTP::pad_get_params_count'],
-      'pad_post_params'        => datastore['HTTP::pad_post_params'],
-      'pad_post_params_count'  => datastore['HTTP::pad_post_params_count'],
-      'shuffle_get_params'     => datastore['HTTP::shuffle_get_params'],
-      'shuffle_post_params'    => datastore['HTTP::shuffle_post_params'],
-      'uri_fake_end'           => datastore['HTTP::uri_fake_end'],
-      'uri_fake_params_start'  => datastore['HTTP::uri_fake_params_start'],
-      'header_folding'         => datastore['HTTP::header_folding'],
-      'domain'                 => datastore['DOMAIN'],
-      'DigestAuthIIS'          => datastore['DigestAuthIIS']
-    )
+      # Configure the HTTP client with the supplied parameter
+      vhost = opts['vhost'] || opts['rhost'] || self.vhost
+      nclient.set_config(
+        'vhost' => vhost,
+        'ssl_server_name_indication' => datastore['SSLServerNameIndication'] || vhost,
+        'agent' => datastore['UserAgent'],
+        'partial' => opts['partial'],
+        'uri_encode_mode' => datastore['HTTP::uri_encode_mode'],
+        'uri_full_url' => datastore['HTTP::uri_full_url'],
+        'pad_method_uri_count' => datastore['HTTP::pad_method_uri_count'],
+        'pad_uri_version_count' => datastore['HTTP::pad_uri_version_count'],
+        'pad_method_uri_type' => datastore['HTTP::pad_method_uri_type'],
+        'pad_uri_version_type' => datastore['HTTP::pad_uri_version_type'],
+        'method_random_valid' => datastore['HTTP::method_random_valid'],
+        'method_random_invalid' => datastore['HTTP::method_random_invalid'],
+        'method_random_case' => datastore['HTTP::method_random_case'],
+        'version_random_valid' => datastore['HTTP::version_random_valid'],
+        'version_random_invalid' => datastore['HTTP::version_random_invalid'],
+        'uri_dir_self_reference' => datastore['HTTP::uri_dir_self_reference'],
+        'uri_dir_fake_relative' => datastore['HTTP::uri_dir_fake_relative'],
+        'uri_use_backslashes' => datastore['HTTP::uri_use_backslashes'],
+        'pad_fake_headers' => datastore['HTTP::pad_fake_headers'],
+        'pad_fake_headers_count' => datastore['HTTP::pad_fake_headers_count'],
+        'pad_get_params' => datastore['HTTP::pad_get_params'],
+        'pad_get_params_count' => datastore['HTTP::pad_get_params_count'],
+        'pad_post_params' => datastore['HTTP::pad_post_params'],
+        'pad_post_params_count' => datastore['HTTP::pad_post_params_count'],
+        'shuffle_get_params' => datastore['HTTP::shuffle_get_params'],
+        'shuffle_post_params' => datastore['HTTP::shuffle_post_params'],
+        'uri_fake_end' => datastore['HTTP::uri_fake_end'],
+        'uri_fake_params_start' => datastore['HTTP::uri_fake_params_start'],
+        'header_folding' => datastore['HTTP::header_folding'],
+        'domain' => datastore['DOMAIN'],
+        'DigestAuthIIS' => datastore['DigestAuthIIS']
+      )
 
-    # NOTE: Please use opts['headers'] to programmatically set headers
-    if datastore['HttpRawHeaders'] && File.readable?(datastore['HttpRawHeaders'])
-      # Templatize with ERB
-      headers = ERB.new(File.read(datastore['HttpRawHeaders'])).result(binding)
+      # NOTE: Please use opts['headers'] to programmatically set headers
+      if datastore['HttpRawHeaders'] && File.readable?(datastore['HttpRawHeaders'])
+        # Templatize with ERB
+        headers = ERB.new(File.read(datastore['HttpRawHeaders'])).result(binding)
 
-      # Append templatized headers to existing headers
-      nclient.set_config('raw_headers' => headers)
-    end
+        # Append templatized headers to existing headers
+        nclient.set_config('raw_headers' => headers)
+      end
 
-    # If this connection is global, persist it
-    # Required for findsock on these sockets
-    if (opts['global'])
-      if (self.client)
+      # If this connection is global, persist it
+      # Required for findsock on these sockets
+      if (opts['global']) && client
         disconnect
       end
+
+      self.client = nclient
+
+      return nclient
     end
 
-    self.client = nclient
+    #
+    # Establish a WebSocket connection to the remote server.
+    #
+    # @raise [Rex::Proto::Http::WebSocket::WebSocketError] raises an exception if the connection fails
+    # @return [Rex::Proto::Http::WebSocket::Interface]
+    def connect_ws(opts = {}, timeout = 20)
+      ws_key = Rex::Text.rand_text_alphanumeric(20)
+      opts['headers'] = opts.fetch('headers', {}).merge({
+        'Connection' => 'Upgrade',
+        'Upgrade' => 'WebSocket',
+        'Sec-WebSocket-Version' => 13,
+        'Sec-WebSocket-Key' => ws_key
+      })
 
-    return nclient
-  end
+      if (http_client = opts['client']).nil?
+        opts['client'] = http_client = connect(opts)
+        raise Rex::Proto::Http::WebSocket::ConnectionError if http_client.nil?
+      end
 
-  #
-  # Establish a WebSocket connection to the remote server.
-  #
-  # @raise [Rex::Proto::Http::WebSocket::WebSocketError] raises an exception if the connection fails
-  # @return [Rex::Proto::Http::WebSocket::Interface]
-  def connect_ws(opts={}, timeout = 20)
-    ws_key = Rex::Text.rand_text_alphanumeric(20)
-    opts['headers'] = opts.fetch('headers', {}).merge({
-      'Connection' => 'Upgrade',
-      'Upgrade' => 'WebSocket',
-      'Sec-WebSocket-Version' => 13,
-      'Sec-WebSocket-Key' => ws_key
-    })
+      res = send_request_raw(opts, timeout, false)
+      unless res&.code == 101
+        disconnect
+        raise Rex::Proto::Http::WebSocket::ConnectionError.new(http_response: res)
+      end
 
-    if (http_client = opts['client']).nil?
-      opts['client'] = http_client = connect(opts)
-      raise Rex::Proto::Http::WebSocket::ConnectionError.new if http_client.nil?
+      # see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-WebSocket-Accept
+      accept_ws_key = Rex::Text.encode_base64(OpenSSL::Digest::SHA1.digest(ws_key + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11'))
+      unless res.headers['Sec-WebSocket-Accept'] == accept_ws_key
+        disconnect
+        raise Rex::Proto::Http::WebSocket::ConnectionError.new(msg: 'Invalid Sec-WebSocket-Accept header', http_response: res)
+      end
+
+      socket = http_client.conn
+      socket.extend(Rex::Proto::Http::WebSocket::Interface)
     end
 
-    res = send_request_raw(opts, timeout, false)
-    unless res&.code == 101
-      disconnect
-      raise Rex::Proto::Http::WebSocket::ConnectionError.new(http_response: res)
+    # Defines a proc to log HTTP requests and responses
+    #
+    # @param http_trace [Bool] A Boolean representing datastore['HttpTrace'] to check if HttpTrace is set or unset.
+    # @param http_trace_headers_only [Bool] A Boolean representing datastore['HttpTraceHeadersOnly'] to check if only HTTP headers need to be logged.
+    # @param http_trace_colors [String] A string representing datastore['HttpTraceColors'] to specify the colors in which request and response need to be logged.
+    # @return [Proc] A Proc object to log HTTP requests and responses, or nil if datastore['HttpTrace'] is unset
+    def set_http_trace_proc(http_trace, http_trace_headers_only, http_trace_colors)
+      proc_httptrace = nil
+      if http_trace
+        proc_httptrace = proc { |request, response|
+          http_trace_colors = '/' if http_trace_colors.empty?
+          request_color, response_color =
+            (http_trace_colors || 'red/blu').gsub('/', ' / ').split('/').map { |color| color&.strip!.blank? ? "" : "%bld#{color}" }
+
+          request = request.to_s(headers_only: http_trace_headers_only)
+          print_line('#' * 20)
+          print_line('# Request:')
+          print_line('#' * 20)
+          print_line("%clr#{request_color}#{request}%clr")
+
+          print_line('#' * 20)
+          print_line('# Response:')
+          print_line('#' * 20)
+
+          if response
+            response = response.to_terminal_output(headers_only: http_trace_headers_only)
+            print_line("%clr#{response_color}#{response}%clr")
+          else
+            print_line('No response received')
+          end
+        }
+      end
+
+      proc_httptrace
     end
 
-    # see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-WebSocket-Accept
-    accept_ws_key = Rex::Text.encode_base64(OpenSSL::Digest::SHA1.digest(ws_key + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11'))
-    unless res.headers['Sec-WebSocket-Accept'] == accept_ws_key
-      disconnect
-      raise Rex::Proto::Http::WebSocket::ConnectionError.new(msg: 'Invalid Sec-WebSocket-Accept header', http_response: res)
+    #
+    # Converts datastore options into configuration parameters for the
+    # Metasploit::LoginScanner::Http class. Any parameters passed into
+    # this method will override the defaults.
+    #
+    def configure_http_login_scanner(conf)
+      {
+        host: rhost,
+        port: rport,
+        ssl: ssl,
+        http_trace: http_trace,
+        http_trace_colors: http_trace_colors,
+        http_trace_headers_only: http_trace_headers_only,
+        ssl_version: ssl_version,
+        proxies: datastore['PROXIES'],
+        framework: framework,
+        framework_module: self,
+        vhost: vhost,
+        user_agent: datastore['UserAgent'],
+        evade_uri_encode_mode: datastore['HTTP::uri_encode_mode'],
+        evade_uri_full_url: datastore['HTTP::uri_full_url'],
+        evade_pad_method_uri_count: datastore['HTTP::pad_method_uri_count'],
+        evade_pad_uri_version_count: datastore['HTTP::pad_uri_version_count'],
+        evade_pad_method_uri_type: datastore['HTTP::pad_method_uri_type'],
+        evade_pad_uri_version_type: datastore['HTTP::pad_uri_version_type'],
+        evade_method_random_valid: datastore['HTTP::method_random_valid'],
+        evade_method_random_invalid: datastore['HTTP::method_random_invalid'],
+        evade_method_random_case: datastore['HTTP::method_random_case'],
+        evade_version_random_valid: datastore['HTTP::version_random_valid'],
+        evade_version_random_invalid: datastore['HTTP::version_random_invalid'],
+        evade_uri_dir_self_reference: datastore['HTTP::uri_dir_self_reference'],
+        evade_uri_dir_fake_relative: datastore['HTTP::uri_dir_fake_relative'],
+        evade_uri_use_backslashes: datastore['HTTP::uri_use_backslashes'],
+        evade_pad_fake_headers: datastore['HTTP::pad_fake_headers'],
+        evade_pad_fake_headers_count: datastore['HTTP::pad_fake_headers_count'],
+        evade_pad_get_params: datastore['HTTP::pad_get_params'],
+        evade_pad_get_params_count: datastore['HTTP::pad_get_params_count'],
+        evade_pad_post_params: datastore['HTTP::pad_post_params'],
+        evade_pad_post_params_count: datastore['HTTP::pad_post_params_count'],
+        evade_shuffle_get_params: datastore['HTTP::shuffle_get_params'],
+        evade_shuffle_post_params: datastore['HTTP::shuffle_post_params'],
+        evade_uri_fake_end: datastore['HTTP::uri_fake_end'],
+        evade_uri_fake_params_start: datastore['HTTP::uri_fake_params_start'],
+        evade_header_folding: datastore['HTTP::header_folding'],
+        ntlm_domain: datastore['DOMAIN'],
+        digest_auth_iis: datastore['DigestAuthIIS']
+      }.merge(conf)
     end
 
-    socket = http_client.conn
-    socket.extend(Rex::Proto::Http::WebSocket::Interface)
-  end
-  
-  
-  # Defines a proc to log HTTP requests and responses
-  #
-  # @param http_trace [Bool] A Boolean representing the datastore['HttpTrace'] to check if HttpTrace is set or unset.
-  # @param http_trace_headers_only [Bool] A Boolean representing the datastore['HttpTraceHeadersOnly'] to check if only HTTP headers need to be logged.
-  # @param http_trace_colors [String] A string representing the datastore['HttpTraceColors'] to specify the colors in which request and response need to be logged.
-  # @return [Proc] A Proc object to log HTTP requests and responses, or nil if the datastore['HttpTrace'] is unset
-  def set_http_trace_proc(http_trace, http_trace_headers_only, http_trace_colors)
-    proc_httptrace = nil
-    if http_trace
-      proc_httptrace = proc { |request, response| 
-        request_color, response_color = 
-          (http_trace_colors || 'red/blu').split('/').map { |color| color.blank? ? "" : "%bld%#{color}" }
-        
-        request = request.to_s(headers_only: http_trace_headers_only)
-        print_line('#' * 20)
-        print_line('# Request:')
-        print_line('#' * 20)
-        print_line("%clr#{request_color}#{request}%clr")
+    #
+    # Passes the client connection down to the handler to see if it's of any
+    # use.
+    #
+    def handler(nsock = nil)
+      # If no socket was provided, try the global one.
+      if (!nsock and client)
+        nsock = client.conn
+      end
 
-        print_line('#' * 20)
-        print_line('# Response:')
-        print_line('#' * 20)
-        
-        if response
-          response = response.to_terminal_output(headers_only: http_trace_headers_only)
-          print_line("%clr#{response_color}#{response}%clr")
-        else
-          print_line('No response received')
+      # If the parent claims the socket associated with the HTTP client, then
+      # we rip the socket out from under the HTTP client.
+      if (((rv = super(nsock)) == Handler::Claimed) and
+          client and
+          (nsock == client.conn))
+        client.conn = nil
+      end
+
+      rv
+    end
+
+    #
+    # Disconnects the HTTP client
+    #
+    def disconnect(nclient = client)
+      if nclient
+        nclient.close
+      end
+
+      if (nclient == client)
+        if client.respond_to?(:close)
+          client.close
         end
-      }
-    end
 
-   proc_httptrace 
-  end
-
-
-  #
-  # Converts datastore options into configuration parameters for the
-  # Metasploit::LoginScanner::Http class. Any parameters passed into
-  # this method will override the defaults.
-  #
-  def configure_http_login_scanner(conf)
-    {
-      host:                          rhost,
-      port:                          rport,
-      ssl:                           ssl,
-      http_trace:                    http_trace,
-      http_trace_colors:             http_trace_colors,
-      http_trace_headers_only:       http_trace_headers_only,
-      ssl_version:                   ssl_version,
-      proxies:                       datastore['PROXIES'],
-      framework:                     framework,
-      framework_module:              self,
-      vhost:                         vhost,
-      user_agent:                    datastore['UserAgent'],
-      evade_uri_encode_mode:         datastore['HTTP::uri_encode_mode'],
-      evade_uri_full_url:            datastore['HTTP::uri_full_url'],
-      evade_pad_method_uri_count:    datastore['HTTP::pad_method_uri_count'],
-      evade_pad_uri_version_count:   datastore['HTTP::pad_uri_version_count'],
-      evade_pad_method_uri_type:     datastore['HTTP::pad_method_uri_type'],
-      evade_pad_uri_version_type:    datastore['HTTP::pad_uri_version_type'],
-      evade_method_random_valid:     datastore['HTTP::method_random_valid'],
-      evade_method_random_invalid:   datastore['HTTP::method_random_invalid'],
-      evade_method_random_case:      datastore['HTTP::method_random_case'],
-      evade_version_random_valid:    datastore['HTTP::version_random_valid'],
-      evade_version_random_invalid:  datastore['HTTP::version_random_invalid'],
-      evade_uri_dir_self_reference:  datastore['HTTP::uri_dir_self_reference'],
-      evade_uri_dir_fake_relative:   datastore['HTTP::uri_dir_fake_relative'],
-      evade_uri_use_backslashes:     datastore['HTTP::uri_use_backslashes'],
-      evade_pad_fake_headers:        datastore['HTTP::pad_fake_headers'],
-      evade_pad_fake_headers_count:  datastore['HTTP::pad_fake_headers_count'],
-      evade_pad_get_params:          datastore['HTTP::pad_get_params'],
-      evade_pad_get_params_count:    datastore['HTTP::pad_get_params_count'],
-      evade_pad_post_params:         datastore['HTTP::pad_post_params'],
-      evade_pad_post_params_count:   datastore['HTTP::pad_post_params_count'],
-      evade_shuffle_get_params:      datastore['HTTP::shuffle_get_params'],
-      evade_shuffle_post_params:     datastore['HTTP::shuffle_post_params'],
-      evade_uri_fake_end:            datastore['HTTP::uri_fake_end'],
-      evade_uri_fake_params_start:   datastore['HTTP::uri_fake_params_start'],
-      evade_header_folding:          datastore['HTTP::header_folding'],
-      ntlm_domain:                   datastore['DOMAIN'],
-      digest_auth_iis:               datastore['DigestAuthIIS']
-    }.merge(conf)
-  end
-
-  #
-  # Passes the client connection down to the handler to see if it's of any
-  # use.
-  #
-  def handler(nsock = nil)
-    # If no socket was provided, try the global one.
-    if ((!nsock) and (self.client))
-      nsock = self.client.conn
-    end
-
-    # If the parent claims the socket associated with the HTTP client, then
-    # we rip the socket out from under the HTTP client.
-    if (((rv = super(nsock)) == Handler::Claimed) and
-        (self.client) and
-        (nsock == self.client.conn))
-      self.client.conn = nil
-    end
-
-    rv
-  end
-
-  #
-  # Disconnects the HTTP client
-  #
-  def disconnect(nclient = self.client)
-    if (nclient)
-      nclient.close
-    end
-
-    if (nclient == self.client)
-      if self.client.respond_to?(:close)
-        self.client.close
+        self.client = nil
       end
-
-      self.client = nil
-    end
-  end
-
-  #
-  # Performs cleanup as necessary, disconnecting the HTTP client if it's
-  # still established.
-  #
-  def cleanup
-    super
-    disconnect
-  end
-
-  #
-  # Connects to the server, creates a request, sends the request, reads the response
-  #
-  # Passes +opts+ through directly to Rex::Proto::Http::Client#request_raw.
-  #
-  def send_request_raw(opts = {}, timeout = 20, disconnect = false)
-    if datastore['HttpClientTimeout'] && datastore['HttpClientTimeout'] > 0
-      actual_timeout = datastore['HttpClientTimeout']
-    else
-      actual_timeout = opts[:timeout] || timeout
     end
 
-    c = opts['client'] || connect(opts)
-    r = opts[:cgi] ? c.request_cgi(opts) : c.request_raw(opts)
-
-    
-    res = c.send_recv(r, actual_timeout)
-
-    disconnect(c) if disconnect
-
-    res
-  rescue ::Errno::EPIPE, ::Timeout::Error => e
-    print_line(e.message) if datastore['HttpTrace']
-    nil
-  rescue Rex::ConnectionError => e
-    vprint_error(e.to_s)
-    nil
-  rescue ::Exception => e
-    print_line(e.message) if datastore['HttpTrace']
-    raise e
-  end
-
-  # Connects to the server, creates a request, sends the request,
-  # reads the response
-  #
-  # If a +Msf::Exploit::Remote::HTTP::HttpCookieJar+ instance is passed in the +opts+ dict under a 'cookie' key, said CookieJar will be used in
-  # the request instead of the module +cookie_jar+. Any other object passed under the `cookie` key will be converted to a string using +to_s+
-  # and set as the cookie header of the request.
-  #
-  # Passes `opts` through directly to {Rex::Proto::Http::Client#request_cgi}.
-  # Set `opts['keep_cookies']` to keep cookies from responses for reuse in requests.
-  # Cookies returned by the server will be stored in +cookie_jar+
-  #
-  # Set `opts['expire_cookies']` to false in order to disable automatic removal of expired cookies
-  #
-  # @return (see Rex::Proto::Http::Client#send_recv))
-  def send_request_cgi(opts = {}, timeout = 20, disconnect = true)
-    if opts.has_key?('cookie')
-      if opts['cookie'].is_a?(Msf::Exploit::Remote::HTTP::HttpCookieJar)
-        opts.merge({ 'cookie' => opts['cookie'].cookies.join('; ') })
-      else
-        opts.merge({ 'cookie' => opts['cookie'].to_s })
-      end
-    elsif !cookie_jar.empty?
-      cookie_jar.cleanup unless opts['expire_cookies'] == false
-      opts = opts.merge({ 'cookie' => cookie_jar.cookies.join('; ') })
-    end
-
-    res = send_request_raw(opts.merge(cgi: true), timeout, disconnect)
-    return unless res
-
-    if opts['keep_cookies'] && res.headers['Set-Cookie'].present?
-      cookie_jar.parse_and_merge(res.headers['Set-Cookie'], "http#{ssl ? 's' : ''}://#{vhost}:#{rport}")
-    end
-
-    res
-  end
-
-  # Connects to the server, creates a request, sends the request, reads the
-  # response if a redirect (HTTP 30x response) is received it will attempt to
-  # follow the direct and retrieve that URI.
-  #
-  # @note `opts` will be updated to the updated location and
-  #   `opts['redirect_uri']` will contain the full URI.
-  #
-  # @return (see #send_request_cgi)
-  def send_request_cgi!(opts = {}, timeout = 20, redirect_depth = 1)
-    res = send_request_cgi(opts, timeout)
-
-    return unless res
-    return res unless res.redirect? && res.redirection && redirect_depth > 0
-
-    redirect_depth -= 1
-
-    reconfig_redirect_opts!(res, opts)
-    send_request_cgi!(opts, timeout, redirect_depth)
-  end
-
-  # Modifies the HTTP request options for a redirection.
-  #
-  # @param res [Rex::Proto::HTTP::Response] HTTP Response.
-  # @param opts [Hash] The HTTP request options to modify.
-  # @return [void]
-  def reconfig_redirect_opts!(res, opts)
-    # XXX: https://github.com/rapid7/metasploit-framework/issues/12281
-    if opts['method'] == 'POST'
-      opts['method'] = 'GET'
-      opts['data'] = nil
-      opts['vars_post'] = {}
-    end
-
-    location = res.redirection
-
-    if location.relative?
-      if location.path.start_with?('/')
-        # path starting with /, not relative to the current path, but starts from the root
-        opts['redirect_uri'] = location.path
-        opts['uri'] = location.path
-      else
-        parent_path = File.dirname(opts['uri'].to_s)
-        parent_path = '/' if parent_path == '.'
-        new_redirect_uri = normalize_uri(parent_path, location.path.gsub(/^\./, ''))
-        opts['redirect_uri'] = new_redirect_uri
-        opts['uri'] = new_redirect_uri
-      end
-
-      opts['rhost'] = datastore['RHOST']
-      opts['vhost'] = opts['vhost'] || self.vhost() || opts['rhost']
-      opts['ssl_server_name_indication'] = datastore['SSLServerNameIndication'] || opts['vhost']
-      opts['rport'] = datastore['RPORT']
-
-      opts['SSL'] = ssl
-    else
+    #
+    # Performs cleanup as necessary, disconnecting the HTTP client if it's
+    # still established.
+    #
+    def cleanup
+      super
       disconnect
-
-      opts['redirect_uri'] = location
-      opts['uri'] = location.path
-      opts['rhost'] = location.host
-      opts['vhost'] = location.host
-      opts['ssl_server_name_indication'] = opts['vhost']
-      opts['rport'] = location.port
-
-      if location.scheme == 'https'
-        opts['SSL'] = true
-      else
-        opts['SSL'] = false
-      end
     end
 
-    # Don't forget any GET parameters
-    opts['query'] ||= location.query if location.query
-  end
+    #
+    # Connects to the server, creates a request, sends the request, reads the response
+    #
+    # Passes +opts+ through directly to Rex::Proto::Http::Client#request_raw.
+    #
+    def send_request_raw(opts = {}, timeout = 20, disconnect = false)
+      if datastore['HttpClientTimeout'] && datastore['HttpClientTimeout'] > 0
+        actual_timeout = datastore['HttpClientTimeout']
+      else
+        actual_timeout = opts[:timeout] || timeout
+      end
 
-  #
-  # Combine the user/pass into an auth string for the HTTP Client
-  #
-  def basic_auth(username, password)
-    auth_str = Rex::Text.encode_base64("#{username}:#{password}")
-    "Basic #{auth_str}"
-  end
+      c = opts['client'] || connect(opts)
+      r = opts[:cgi] ? c.request_cgi(opts) : c.request_raw(opts)
 
-  ##
-  #
-  # Wrappers for getters
-  #
-  ##
+      res = c.send_recv(r, actual_timeout)
 
-  #
-  # Returns the target URI
-  #
-  def target_uri
-    begin
+      disconnect(c) if disconnect
+
+      res
+    rescue ::Errno::EPIPE, ::Timeout::Error => e
+      print_line(e.message) if datastore['HttpTrace']
+      nil
+    rescue Rex::ConnectionError => e
+      vprint_error(e.to_s)
+      nil
+    rescue ::Exception => e
+      print_line(e.message) if datastore['HttpTrace']
+      raise e
+    end
+
+    # Connects to the server, creates a request, sends the request,
+    # reads the response
+    #
+    # If a +Msf::Exploit::Remote::HTTP::HttpCookieJar+ instance is passed in the +opts+ dict under a 'cookie' key, said CookieJar will be used in
+    # the request instead of the module +cookie_jar+. Any other object passed under the `cookie` key will be converted to a string using +to_s+
+    # and set as the cookie header of the request.
+    #
+    # Passes `opts` through directly to {Rex::Proto::Http::Client#request_cgi}.
+    # Set `opts['keep_cookies']` to keep cookies from responses for reuse in requests.
+    # Cookies returned by the server will be stored in +cookie_jar+
+    #
+    # Set `opts['expire_cookies']` to false in order to disable automatic removal of expired cookies
+    #
+    # @return (see Rex::Proto::Http::Client#send_recv))
+    def send_request_cgi(opts = {}, timeout = 20, disconnect = true)
+      if opts.has_key?('cookie')
+        if opts['cookie'].is_a?(Msf::Exploit::Remote::HTTP::HttpCookieJar)
+          opts.merge({ 'cookie' => opts['cookie'].cookies.join('; ') })
+        else
+          opts.merge({ 'cookie' => opts['cookie'].to_s })
+        end
+      elsif !cookie_jar.empty?
+        cookie_jar.cleanup unless opts['expire_cookies'] == false
+        opts = opts.merge({ 'cookie' => cookie_jar.cookies.join('; ') })
+      end
+
+      res = send_request_raw(opts.merge(cgi: true), timeout, disconnect)
+      return unless res
+
+      if opts['keep_cookies'] && res.headers['Set-Cookie'].present?
+        cookie_jar.parse_and_merge(res.headers['Set-Cookie'], "http#{ssl ? 's' : ''}://#{vhost}:#{rport}")
+      end
+
+      res
+    end
+
+    # Connects to the server, creates a request, sends the request, reads the
+    # response if a redirect (HTTP 30x response) is received it will attempt to
+    # follow the direct and retrieve that URI.
+    #
+    # @note `opts` will be updated to the updated location and
+    #   `opts['redirect_uri']` will contain the full URI.
+    #
+    # @return (see #send_request_cgi)
+    def send_request_cgi!(opts = {}, timeout = 20, redirect_depth = 1)
+      res = send_request_cgi(opts, timeout)
+
+      return unless res
+      return res unless res.redirect? && res.redirection && redirect_depth > 0
+
+      redirect_depth -= 1
+
+      reconfig_redirect_opts!(res, opts)
+      send_request_cgi!(opts, timeout, redirect_depth)
+    end
+
+    # Modifies the HTTP request options for a redirection.
+    #
+    # @param res [Rex::Proto::HTTP::Response] HTTP Response.
+    # @param opts [Hash] The HTTP request options to modify.
+    # @return [void]
+    def reconfig_redirect_opts!(res, opts)
+      # XXX: https://github.com/rapid7/metasploit-framework/issues/12281
+      if opts['method'] == 'POST'
+        opts['method'] = 'GET'
+        opts['data'] = nil
+        opts['vars_post'] = {}
+      end
+
+      location = res.redirection
+
+      if location.relative?
+        if location.path.start_with?('/')
+          # path starting with /, not relative to the current path, but starts from the root
+          opts['redirect_uri'] = location.path
+          opts['uri'] = location.path
+        else
+          parent_path = File.dirname(opts['uri'].to_s)
+          parent_path = '/' if parent_path == '.'
+          new_redirect_uri = normalize_uri(parent_path, location.path.gsub(/^\./, ''))
+          opts['redirect_uri'] = new_redirect_uri
+          opts['uri'] = new_redirect_uri
+        end
+
+        opts['rhost'] = datastore['RHOST']
+        opts['vhost'] = opts['vhost'] || vhost || opts['rhost']
+        opts['ssl_server_name_indication'] = datastore['SSLServerNameIndication'] || opts['vhost']
+        opts['rport'] = datastore['RPORT']
+
+        opts['SSL'] = ssl
+      else
+        disconnect
+
+        opts['redirect_uri'] = location
+        opts['uri'] = location.path
+        opts['rhost'] = location.host
+        opts['vhost'] = location.host
+        opts['ssl_server_name_indication'] = opts['vhost']
+        opts['rport'] = location.port
+
+        if location.scheme == 'https'
+          opts['SSL'] = true
+        else
+          opts['SSL'] = false
+        end
+      end
+
+      # Don't forget any GET parameters
+      opts['query'] ||= location.query if location.query
+    end
+
+    #
+    # Combine the user/pass into an auth string for the HTTP Client
+    #
+    def basic_auth(username, password)
+      auth_str = Rex::Text.encode_base64("#{username}:#{password}")
+      "Basic #{auth_str}"
+    end
+
+    ##
+    #
+    # Wrappers for getters
+    #
+    ##
+
+    #
+    # Returns the target URI
+    #
+    def target_uri
       # In case TARGETURI is empty, at least we default to '/'
       u = datastore['TARGETURI']
-      u = "/" if u.nil? or u.empty?
+      u = '/' if u.nil? or u.empty?
       URI(u)
     rescue ::URI::InvalidURIError
       print_error "Invalid URI: #{datastore['TARGETURI'].inspect}"
-      raise Msf::OptionValidateError.new(['TARGETURI'])
-    end
-  end
-
-  # Returns the complete URI as string including the scheme, port and host
-  def full_uri(custom_uri = nil, vhost_uri: false)
-    uri_scheme = ssl ? 'https' : 'http'
-
-    if (rport == 80 && !ssl) || (rport == 443 && ssl)
-      uri_port = ''
-    else
-      uri_port = ":#{rport}"
+      raise Msf::OptionValidateError, ['TARGETURI']
     end
 
-    uri = normalize_uri(custom_uri || target_uri.to_s)
+    # Returns the complete URI as string including the scheme, port and host
+    def full_uri(custom_uri = nil, vhost_uri: false)
+      uri_scheme = ssl ? 'https' : 'http'
 
-    if vhost_uri && datastore['VHOST']
-      uri_host = datastore['VHOST']
-    elsif Rex::Socket.is_ipv6?(rhost)
-      uri_host = "[#{rhost}]"
-    else
-      uri_host = rhost
+      if (rport == 80 && !ssl) || (rport == 443 && ssl)
+        uri_port = ''
+      else
+        uri_port = ":#{rport}"
+      end
+
+      uri = normalize_uri(custom_uri || target_uri.to_s)
+
+      if vhost_uri && datastore['VHOST']
+        uri_host = datastore['VHOST']
+      elsif Rex::Socket.is_ipv6?(rhost)
+        uri_host = "[#{rhost}]"
+      else
+        uri_host = rhost
+      end
+
+      "#{uri_scheme}://#{uri_host}#{uri_port}#{uri}"
     end
 
-    "#{uri_scheme}://#{uri_host}#{uri_port}#{uri}"
-  end
+    #
+    # Returns a modified version of the URI that:
+    # 1. Always has a starting slash
+    # 2. Removes all the double slashes
+    #
+    def normalize_uri(*strs)
+      new_str = strs * '/'
 
-  #
-  # Returns a modified version of the URI that:
-  # 1. Always has a starting slash
-  # 2. Removes all the double slashes
-  #
-  def normalize_uri(*strs)
-    new_str = strs * "/"
+      new_str = new_str.gsub!('//', '/') while new_str.index('//')
 
-    new_str = new_str.gsub!("//", "/") while new_str.index("//")
+      # Makes sure there's a starting slash
+      unless new_str[0, 1] == '/'
+        new_str = '/' + new_str
+      end
 
-    # Makes sure there's a starting slash
-    unless new_str[0,1] == '/'
-      new_str = '/' + new_str
+      new_str
     end
 
-    new_str
-  end
-
-  # Returns the Path+Query from a full URI String, nil on error
-  def path_from_uri(uri)
-    begin
+    # Returns the Path+Query from a full URI String, nil on error
+    def path_from_uri(uri)
       temp = URI(uri)
       ret_uri = temp.path
       ret_uri << "?#{temp.query}" unless temp.query.nil? or temp.query.empty?
@@ -621,375 +611,381 @@ module Exploit::Remote::HttpClient
       print_error "Invalid URI: #{uri}"
       return nil
     end
-  end
 
-  #
-  # Returns a hash of request opts from a URL string
-  def request_opts_from_url(url)
-    # verify and extract components from the URL
-    begin
-      tgt = URI.parse(url)
-      raise 'Invalid URL' unless tgt.scheme =~ %r{https?}
-      raise 'Invalid URL' if tgt.host.to_s.eql? ''
-    rescue => e
-      print_error "Could not parse URL: #{e}"
-      return nil
-    end
-
-    opts = { 'rhost' => tgt.host, 'rport' => tgt.port, 'uri' => tgt.request_uri }
-    opts['SSL'] = true if tgt.scheme == 'https'
-    if tgt.query and tgt.query.size > 13
-      # Assming that this is going to be mostly used for GET requests as string -> req
-      opts['vars_get'] = {}
-      tgt.query.split('&').each do |pair|
-        k,v = pair.split('=',2)
-        opts['vars_get'][k] = v
-      end
-    end
-    return opts
-  end
-
-  #
-  # Returns response from a simple URL call
-  def request_url(url, keepalive = false)
-    opts = request_opts_from_url(url)
-    return nil if opts.nil?
-    res = send_request_raw(opts)
-    disconnect unless keepalive
-    return res
-  end
-
-  #
-  # Downloads a URL
-  def download(url)
-    print_status "Downloading '#{url}'"
-
-    begin
-      target = URI.parse url
-      raise 'Invalid URL' unless target.scheme =~ /https?/
-      raise 'Invalid URL' if target.host.to_s.eql? ''
-    rescue => e
-      print_error "Could not parse URL: #{e}"
-      return nil
-    end
-
-    res = request_url(url)
-
-    unless res
-      print_error 'Connection failed'
-      return nil
-    end
-
-    print_status "- HTTP #{res.code} - #{res.body.length} bytes"
-
-    res.code == 200 ? res.body : nil
-  end
-
-  # removes HTML tags from a provided string.
-  # The string is html-unescaped before the tags are removed
-  # Leading whitespaces and double linebreaks are removed too
-  def strip_tags(html)
-    Rex::Text.html_decode(html).gsub(/<\/?[^>]*>/, '').gsub(/^\s+/, '').strip
-  end
-
-  #
-  # Returns the target host
-  #
-  def rhost
-    datastore['RHOST']
-  end
-
-  #
-  # Returns the remote port
-  #
-  def rport
-    datastore['RPORT']
-  end
-
-  #
-  # Returns the Host and Port as a string
-  #
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
-  #
-  # Returns the VHOST of the HTTP server.
-  #
-  def vhost
-    datastore['VHOST'] || datastore['RHOST']
-  end
-
-  #
-  # Returns the boolean indicating SSL
-  #
-  def ssl
-    ((datastore.default?('SSL') and [443,3790].include?(rport.to_i)) or datastore['SSL'])
-  end
-
-  #
-  # Returns the string indicating SSL version
-  #
-  def ssl_version
-    datastore['SSLVersion']
-  end
-
-  #
-  # Returns the configured proxy list
-  #
-  def proxies
-    datastore['Proxies']
-  end
-
-  # 
-  # Returns the configured datastore option for HttpTrace
-  #
-  def http_trace
-    datastore['HttpTrace']
-  end
-
-  #
-  # Returns the datastore option for HttpTraceHeadersOnly
-  #
-  def http_trace_headers_only
-    datastore['HttpTraceHeadersOnly']
-  end
-
-  # 
-  # Returns the datastore option for HttpTraceColors
-  #
-  def http_trace_colors
-    datastore['HttpTraceColors']
-  end
-
-
-  #
-  # Lookup HTTP fingerprints from the database that match the current
-  # destination host and port. This method falls back to using the old
-  # service.info field to represent the HTTP Server header.
-  #
-  # @option opts [String] :uri ('/') An HTTP URI to request in order to generate
-  #   a fingerprint
-  # @option opts [String] :method ('GET') An HTTP method to use in the fingerprint
-  #   request
-  def lookup_http_fingerprints(opts={})
-    uri     = opts[:uri] || '/'
-    method  = opts[:method] || 'GET'
-    fprints = []
-
-    return fprints unless framework.db.active
-
-    ::ApplicationRecord.connection_pool.with_connection {
-      wspace = datastore['WORKSPACE'] ?
-        framework.db.find_workspace(datastore['WORKSPACE']) : framework.db.workspace
-
-      # only one result can be returned, as the +port+ field restricts potential results to a single service
-      service = framework.db.services(:workspace => wspace,
-                                      :hosts => {address: rhost},
-                                      :proto => 'tcp',
-                                      :port => rport).first
-      return fprints unless service
-
-      # Order by note_id descending so the first value is the most recent
-      service.notes.where(:ntype => 'http.fingerprint').order("notes.id DESC").each do |n|
-        next unless n.data && n.data.kind_of?(::Hash)
-        next unless n.data[:uri] == uri && n.data[:method] == method
-        # Append additional fingerprints to the results as found
-        fprints.unshift n.data.dup
-      end
-    }
-
-    fprints
-  end
-
-  #
-  # Record various things about an HTTP server that we can glean from the
-  # response to a single request.  If this method is passed a response, it
-  # will use it directly, otherwise it will check the database for a previous
-  # fingerprint.  Failing that, it will make a request for /.
-  #
-  # Other options are passed directly to {#connect} if :response is not given
-  #
-  # @option opts [Rex::Proto::Http::Packet] :response The return value from any
-  #   of the send_* methods
-  # @option opts [String] :uri ('/') An HTTP URI to request in order to generate
-  #   a fingerprint
-  # @option opts [String] :method ('GET') An HTTP method to use in the fingerprint
-  #   request
-  # @option opts [Boolean] :full (false) Request the full HTTP fingerprint, not
-  #   just the signature
-  #
-  # @return [String]
-  def http_fingerprint(opts={})
-    res    = nil
-    uri    = opts[:uri] || '/'
-    method = opts[:method] || 'GET'
-
-    # Short-circuit the fingerprint lookup and HTTP request if a response has
-    # already been provided by the caller.
-    if opts[:response]
-      res = opts[:response]
-    else
-      fprints = lookup_http_fingerprints(opts)
-
-      if fprints.length > 0
-
-        # Grab the most recent fingerprint available for this service, uri, and method
-        fprint = fprints.last
-
-        # Return the full HTTP fingerprint if requested by the caller
-        return fprint if opts[:full]
-
-        # Otherwise just return the signature string for compatibility
-        return fprint[:signature]
+    #
+    # Returns a hash of request opts from a URL string
+    def request_opts_from_url(url)
+      # verify and extract components from the URL
+      begin
+        tgt = URI.parse(url)
+        raise 'Invalid URL' unless tgt.scheme =~ /https?/
+        raise 'Invalid URL' if tgt.host.to_s.eql? ''
+      rescue StandardError => e
+        print_error "Could not parse URL: #{e}"
+        return nil
       end
 
-      # Go ahead and send a request to the target for fingerprinting
-      connect(opts)
-      res = send_request_raw(
-        {
-          'uri'     => uri,
-          'method'  => method
-        }) rescue nil
-    end
-
-    # Bail if the request did not receive a readable response
-    return if not res
-
-    # This section handles a few simple cases of pattern matching and service
-    # classification. This logic should be deprecated in favor of Recog-based
-    # fingerprint databases, but has been left in place for backward compat.
-
-    extras = []
-
-    if res.headers['Set-Cookie'] =~ /^vmware_soap_session/
-      extras << "VMWare Web Services"
-    end
-
-    if (res.headers['X-Powered-By'])
-      extras << "Powered by " + res.headers['X-Powered-By']
-    end
-
-    if (res.headers['Via'])
-      extras << "Via-" + res.headers['Via']
-    end
-
-    if (res.headers['X-AspNet-Version'])
-      extras << "AspNet-Version-" + res.headers['X-AspNet-Version']
-    end
-
-    case res.body
-      when nil
-        # Nothing
-      when /openAboutWindow.*\>DD\-WRT ([^\<]+)\<|Authorization.*please note that the default username is \"root\" in/
-        extras << "DD-WRT #{$1.to_s.strip}".strip
-
-      when /ID_ESX_Welcome/, /ID_ESX_VIClientDesc/
-        extras << "VMware ESX Server"
-
-      when /Test Page for.*Fedora/
-        extras << "Fedora Default Page"
-
-      when /Placeholder page/
-        extras << "Debian Default Page"
-
-      when /Welcome to Windows Small Business Server (\d+)/
-        extras << "Windows SBS #{$1}"
-
-      when /Asterisk@Home/
-        extras << "Asterisk"
-
-      when /swfs\/Shell\.html/
-        extras << "BPS-1000"
-    end
-
-    if datastore['RPORT'].to_i == 3790
-      if res.code == 302 and res.headers and res.headers['Location'] =~ /[\x5c\x2f](login|setup)$/n
-        if res['Server'] =~ /^(thin.*No Hup)|(nginx[\x5c\x2f][\d\.]+)$/n
-          extras << "Metasploit"
+      opts = { 'rhost' => tgt.host, 'rport' => tgt.port, 'uri' => tgt.request_uri }
+      opts['SSL'] = true if tgt.scheme == 'https'
+      if tgt.query and tgt.query.size > 13
+        # Assming that this is going to be mostly used for GET requests as string -> req
+        opts['vars_get'] = {}
+        tgt.query.split('&').each do |pair|
+          k, v = pair.split('=', 2)
+          opts['vars_get'][k] = v
         end
       end
+      return opts
     end
 
     #
-    # This HTTP response code tracking is used by a few modules and the MSP logic
-    # to identify and bruteforce certain types of servers. In the long run we
-    # should deprecate this and use the http.fingerprint fields instead.
+    # Returns response from a simple URL call
+    def request_url(url, keepalive = false)
+      opts = request_opts_from_url(url)
+      return nil if opts.nil?
+
+      res = send_request_raw(opts)
+      disconnect unless keepalive
+      return res
+    end
+
     #
-    case res.code
-    when 301,302
-      extras << "#{res.code}-#{res.headers['Location']}"
-    when 401
-      extras << "#{res.code}-#{res.headers['WWW-Authenticate']}"
-    when 403
-      extras << "#{res.code}-#{res.headers['WWW-Authenticate']||res.message}"
-    when 500 .. 599
-      extras << "#{res.code}-#{res.message}"
+    # Downloads a URL
+    def download(url)
+      print_status "Downloading '#{url}'"
+
+      begin
+        target = URI.parse url
+        raise 'Invalid URL' unless target.scheme =~ /https?/
+        raise 'Invalid URL' if target.host.to_s.eql? ''
+      rescue StandardError => e
+        print_error "Could not parse URL: #{e}"
+        return nil
+      end
+
+      res = request_url(url)
+
+      unless res
+        print_error 'Connection failed'
+        return nil
+      end
+
+      print_status "- HTTP #{res.code} - #{res.body.length} bytes"
+
+      res.code == 200 ? res.body : nil
     end
 
-    # Build a human-readable string to store in service.info and http.fingerprint[:signature]
-    info = res.headers['Server'].to_s.dup
-    info << " ( #{extras.join(", ")} )" if extras.length > 0
-
-    # Create a new fingerprint structure to track this response
-    fprint = {
-      :uri => uri, :method => method, :server_port => rport,
-      :code => res.code.to_s, :message => res.message.to_s,
-      :signature => info
-    }
-
-    res.headers.each_pair do |k,v|
-      hname = k.to_s.downcase.tr('-', '_').gsub(/[^a-z0-9_]+/, '')
-      next unless hname.length > 0
-
-      # Set-Cookie >        :header_set_cookie       => JSESSIONID=AAASD23423452
-      # Server >            :header_server           => Apache/1.3.37
-      # WWW-Authenticate >  :header_www_authenticate => basic realm='www'
-
-      fprint["header_#{hname}".intern] = v
+    # removes HTML tags from a provided string.
+    # The string is html-unescaped before the tags are removed
+    # Leading whitespaces and double linebreaks are removed too
+    def strip_tags(html)
+      Rex::Text.html_decode(html).gsub(%r{</?[^>]*>}, '').gsub(/^\s+/, '').strip
     end
 
-    # Store the first 64k of the HTTP body as well
-    fprint[:content] = res.body.to_s[0,65535]
+    #
+    # Returns the target host
+    #
+    def rhost
+      datastore['RHOST']
+    end
 
-    # Report a new http.fingerprint note
-    report_note(
-      :host   => rhost,
-      :port   => rport,
-      :proto  => 'tcp',
-      :ntype  => 'http.fingerprint',
-      :data   => fprint,
-      # Limit reporting to one stored note per host/service combination
-      :update => :unique
-    )
+    #
+    # Returns the remote port
+    #
+    def rport
+      datastore['RPORT']
+    end
 
-    # Report here even if info is empty since the fact that we didn't
-    # return early means we at least got a connection and the service is up
-    report_web_site(:host => rhost, :port => rport, :ssl => ssl, :vhost => vhost, :info => info.dup)
+    #
+    # Returns the Host and Port as a string
+    #
+    def peer
+      "#{rhost}:#{rport}"
+    end
 
-    # Return the full HTTP fingerprint if requested by the caller
-    return fprint if opts[:full]
+    #
+    # Returns the VHOST of the HTTP server.
+    #
+    def vhost
+      datastore['VHOST'] || datastore['RHOST']
+    end
 
-    # Otherwise just return the signature string for compatibility
-    fprint[:signature]
+    #
+    # Returns the boolean indicating SSL
+    #
+    def ssl
+      ((datastore.default?('SSL') and [443, 3790].include?(rport.to_i)) or datastore['SSL'])
+    end
+
+    #
+    # Returns the string indicating SSL version
+    #
+    def ssl_version
+      datastore['SSLVersion']
+    end
+
+    #
+    # Returns the configured proxy list
+    #
+    def proxies
+      datastore['Proxies']
+    end
+
+    #
+    # Returns the configured datastore option for HttpTrace
+    #
+    def http_trace
+      datastore['HttpTrace']
+    end
+
+    #
+    # Returns the datastore option for HttpTraceHeadersOnly
+    #
+    def http_trace_headers_only
+      datastore['HttpTraceHeadersOnly']
+    end
+
+    #
+    # Returns the datastore option for HttpTraceColors
+    #
+    def http_trace_colors
+      datastore['HttpTraceColors']
+    end
+
+    #
+    # Lookup HTTP fingerprints from the database that match the current
+    # destination host and port. This method falls back to using the old
+    # service.info field to represent the HTTP Server header.
+    #
+    # @option opts [String] :uri ('/') An HTTP URI to request in order to generate
+    #   a fingerprint
+    # @option opts [String] :method ('GET') An HTTP method to use in the fingerprint
+    #   request
+    def lookup_http_fingerprints(opts = {})
+      uri = opts[:uri] || '/'
+      method = opts[:method] || 'GET'
+      fprints = []
+
+      return fprints unless framework.db.active
+
+      ::ApplicationRecord.connection_pool.with_connection do
+        wspace = if datastore['WORKSPACE']
+                   framework.db.find_workspace(datastore['WORKSPACE'])
+                 else
+                   framework.db.workspace
+                 end
+
+        # only one result can be returned, as the +port+ field restricts potential results to a single service
+        service = framework.db.services(workspace: wspace,
+                                        hosts: { address: rhost },
+                                        proto: 'tcp',
+                                        port: rport).first
+        return fprints unless service
+
+        # Order by note_id descending so the first value is the most recent
+        service.notes.where(ntype: 'http.fingerprint').order('notes.id DESC').each do |n|
+          next unless n.data && n.data.is_a?(::Hash)
+          next unless n.data[:uri] == uri && n.data[:method] == method
+
+          # Append additional fingerprints to the results as found
+          fprints.unshift n.data.dup
+        end
+      end
+
+      fprints
+    end
+
+    #
+    # Record various things about an HTTP server that we can glean from the
+    # response to a single request.  If this method is passed a response, it
+    # will use it directly, otherwise it will check the database for a previous
+    # fingerprint.  Failing that, it will make a request for /.
+    #
+    # Other options are passed directly to {#connect} if :response is not given
+    #
+    # @option opts [Rex::Proto::Http::Packet] :response The return value from any
+    #   of the send_* methods
+    # @option opts [String] :uri ('/') An HTTP URI to request in order to generate
+    #   a fingerprint
+    # @option opts [String] :method ('GET') An HTTP method to use in the fingerprint
+    #   request
+    # @option opts [Boolean] :full (false) Request the full HTTP fingerprint, not
+    #   just the signature
+    #
+    # @return [String]
+    def http_fingerprint(opts = {})
+      res = nil
+      uri = opts[:uri] || '/'
+      method = opts[:method] || 'GET'
+
+      # Short-circuit the fingerprint lookup and HTTP request if a response has
+      # already been provided by the caller.
+      if opts[:response]
+        res = opts[:response]
+      else
+        fprints = lookup_http_fingerprints(opts)
+
+        if fprints.length > 0
+
+          # Grab the most recent fingerprint available for this service, uri, and method
+          fprint = fprints.last
+
+          # Return the full HTTP fingerprint if requested by the caller
+          return fprint if opts[:full]
+
+          # Otherwise just return the signature string for compatibility
+          return fprint[:signature]
+        end
+
+        # Go ahead and send a request to the target for fingerprinting
+        connect(opts)
+        res = begin
+          send_request_raw(
+            {
+              'uri' => uri,
+              'method' => method
+            }
+          )
+        rescue StandardError
+          nil
+        end
+      end
+
+      # Bail if the request did not receive a readable response
+      return if !res
+
+      # This section handles a few simple cases of pattern matching and service
+      # classification. This logic should be deprecated in favor of Recog-based
+      # fingerprint databases, but has been left in place for backward compat.
+
+      extras = []
+
+      if res.headers['Set-Cookie'] =~ /^vmware_soap_session/
+        extras << 'VMWare Web Services'
+      end
+
+      if res.headers['X-Powered-By']
+        extras << 'Powered by ' + res.headers['X-Powered-By']
+      end
+
+      if res.headers['Via']
+        extras << 'Via-' + res.headers['Via']
+      end
+
+      if res.headers['X-AspNet-Version']
+        extras << 'AspNet-Version-' + res.headers['X-AspNet-Version']
+      end
+
+      case res.body
+      when nil
+      # Nothing
+      when /openAboutWindow.*>DD-WRT ([^<]+)<|Authorization.*please note that the default username is "root" in/
+        extras << "DD-WRT #{::Regexp.last_match(1).to_s.strip}".strip
+
+      when /ID_ESX_Welcome/, /ID_ESX_VIClientDesc/
+        extras << 'VMware ESX Server'
+
+      when /Test Page for.*Fedora/
+        extras << 'Fedora Default Page'
+
+      when /Placeholder page/
+        extras << 'Debian Default Page'
+
+      when /Welcome to Windows Small Business Server (\d+)/
+        extras << "Windows SBS #{::Regexp.last_match(1)}"
+
+      when /Asterisk@Home/
+        extras << 'Asterisk'
+
+      when %r{swfs/Shell\.html}
+        extras << 'BPS-1000'
+      end
+
+      if datastore['RPORT'].to_i == 3790 && (res.code == 302 and res.headers and res.headers['Location'] =~ /[\x5c\x2f](login|setup)$/n) && (res['Server'] =~ /^(thin.*No Hup)|(nginx[\x5c\x2f][\d.]+)$/n)
+        extras << 'Metasploit'
+      end
+
+      #
+      # This HTTP response code tracking is used by a few modules and the MSP logic
+      # to identify and bruteforce certain types of servers. In the long run we
+      # should deprecate this and use the http.fingerprint fields instead.
+      #
+      case res.code
+      when 301, 302
+        extras << "#{res.code}-#{res.headers['Location']}"
+      when 401
+        extras << "#{res.code}-#{res.headers['WWW-Authenticate']}"
+      when 403
+        extras << "#{res.code}-#{res.headers['WWW-Authenticate'] || res.message}"
+      when 500..599
+        extras << "#{res.code}-#{res.message}"
+      end
+
+      # Build a human-readable string to store in service.info and http.fingerprint[:signature]
+      info = res.headers['Server'].to_s.dup
+      info << " ( #{extras.join(', ')} )" if extras.length > 0
+
+      # Create a new fingerprint structure to track this response
+      fprint = {
+        uri: uri, method: method, server_port: rport,
+        code: res.code.to_s, message: res.message.to_s,
+        signature: info
+      }
+
+      res.headers.each_pair do |k, v|
+        hname = k.to_s.downcase.tr('-', '_').gsub(/[^a-z0-9_]+/, '')
+        next unless hname.length > 0
+
+        # Set-Cookie >        :header_set_cookie       => JSESSIONID=AAASD23423452
+        # Server >            :header_server           => Apache/1.3.37
+        # WWW-Authenticate >  :header_www_authenticate => basic realm='www'
+
+        fprint["header_#{hname}".intern] = v
+      end
+
+      # Store the first 64k of the HTTP body as well
+      fprint[:content] = res.body.to_s[0, 65535]
+
+      # Report a new http.fingerprint note
+      report_note(
+        host: rhost,
+        port: rport,
+        proto: 'tcp',
+        ntype: 'http.fingerprint',
+        data: fprint,
+        # Limit reporting to one stored note per host/service combination
+        update: :unique
+      )
+
+      # Report here even if info is empty since the fact that we didn't
+      # return early means we at least got a connection and the service is up
+      report_web_site(host: rhost, port: rport, ssl: ssl, vhost: vhost, info: info.dup)
+
+      # Return the full HTTP fingerprint if requested by the caller
+      return fprint if opts[:full]
+
+      # Otherwise just return the signature string for compatibility
+      fprint[:signature]
+    end
+
+    def service_details
+      {
+        origin_type: :service,
+        protocol: 'tcp',
+        service_name: (ssl ? 'https' : 'http'),
+        address: rhost,
+        port: rport
+      }
+    end
+
+    attr_reader :cookie_jar
+
+    protected
+
+    attr_accessor :client
+
+    private
+
+    attr_writer :cookie_jar
   end
-
-  def service_details
-    {
-      origin_type: :service,
-      protocol: 'tcp',
-      service_name: (ssl ? 'https' : 'http'),
-      address: rhost,
-      port: rport
-    }
-  end
-
-  attr_reader :cookie_jar
-
-  protected
-  attr_accessor :client
-
-  private
-  attr_writer :cookie_jar
-end
 end

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -138,6 +138,40 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
       ]
     }
 
+    let(:http_trace_single_color_output_leading_slash) {
+      [
+        "####################",
+        "# Request:",
+        "####################",
+        "%clr%bld%GET / HTTP/1.1",
+        "Host: www.google.com%clr",
+        "####################",
+        "# Response:",
+        "####################",
+        "%clr%bld%yelHTTP/1.1 302 Found\r",
+        "\r",
+        "Location: https://www.google.com/?gws_rd=ssl%clr"
+      ]
+    }
+
+    let(:http_trace_no_color_output) {
+      [
+        "####################",
+        "# Request:",
+        "####################",
+        "%clrGET / HTTP/1.1",
+        "Host: www.google.com%clr",
+        "####################",
+        "# Response:",
+        "####################",
+        "%clrHTTP/1.1 302 Found\r",
+        "\r",
+        "Location: https://www.google.com/?gws_rd=ssl%clr"
+      ]
+    }
+
+
+
     it 'returns a proc object when HttpTrace is set to true' do
       expect(subject.set_http_trace_proc(true, false, nil)).to be_kind_of(Proc)
     end
@@ -175,6 +209,16 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
     it 'should only log HTTP request in color when only one colour is specified' do
       subject.set_http_trace_proc(true, false, 'yel/').call(sample_request, sample_response)
       expect(@output).to eq http_trace_single_color_output
+    end
+
+    it 'should only log HTTP response in color when only one colour is specified after a leading "/"' do
+      subject.set_http_trace_proc(true, false, '/yel').call(sample_request, sample_response)
+      expect(@output).to eq http_trace_single_color_output_leading_slash
+    end
+
+    it 'should not log HTTP request and response in color when HttpTraceColors is set to "/"' do
+      subject.set_http_trace_proc(true, false, '/').call(sample_request, sample_response)
+      expect(@output).to eq http_trace_no_color_output
     end
 
     it 'should only log HTTP request in color when only one color is specified without "/"' do

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -7,37 +7,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
   include_context 'Msf::UIDriver'
   include_context 'Msf::DBManager'
   include_context 'Msf::Simple::Framework'
-
-  # let(:driver) do
-  #   instance = double('Rex::Ui::Text::Output::Stdio', framework: framework)
-  #   #require 'pry';binding.pry
-  #   allow(instance).to receive(:print_line) { |arg| $stdout.puts arg }
-  #   capture_logging(instance)
-  #   instance
-  # end
-
-  #class Metasploit::Framework::LoginScanner::HTTP
-  #  def print_line(mesg='')
-  #    print(mesg+"\n")
-  #  end
-  #end
-
-  #class Rex::Proto::Http::Packet
-  #  def to_terminal_output(headers_only=false)
-  #    output_packet(true, headers_only=headers_only)
-  #  end
-
-  #  def to_s(headers_only=false)
-  #    output_packet(false, headers_only=headers_only)
-  #  end
-  #end
-
-  #class Rex::Ui::Text::Output::Stdio
-  #  def support_color?
-  #    return false
-  #  end
-  #end
-
+  
   it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
   it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'
   it_behaves_like 'Metasploit::Framework::LoginScanner::HTTP'
@@ -55,8 +25,6 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
     allow_any_instance_of(Rex::Proto::Http::Client).to receive(:request_cgi).with(any_args)
     allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).with(any_args).and_return(response)
     allow_any_instance_of(Rex::Proto::Http::Client).to receive(:set_config).with(any_args)
-    #allow().to receive(:print_line) { |arg| $stdout.puts arg }
-    allow(subject).to receive(:print) { |arg| $stdout.puts arg }
     allow_any_instance_of(Rex::Proto::Http::Client).to receive(:close)
     allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect)
   end
@@ -74,8 +42,8 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
       "GET / HTTP/1.1\nHost: www.google.com"
     }
     let(:sample_response) {
-      res = Rex::Proto::Http::Response.new
-      allow(res).to receive(:body).and_return("HTTP/1.1 302 Found\nLocation: https://www.google.com/?gws_rd=ssl")
+      res = Rex::Proto::Http::Response.new(302,'Found')
+      allow(res).to receive(:body).and_return("Location: https://www.google.com/?gws_rd=ssl")
       res
     }
     let(:expected_output) {
@@ -88,9 +56,8 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
         "####################",
         "# Response:",
         "####################",
-        "%clr%bld%bluHTTP/1.1 200 OK\r",
+        "%clr%bld%bluHTTP/1.1 302 Found\r",
         "\r",
-        "HTTP/1.1 302 Found",
         "Location: https://www.google.com/?gws_rd=ssl%clr"
       ]
     }
@@ -104,9 +71,36 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
         "####################",
         "# Response:",
         "####################",
-        "%clr%bld%bluHTTP/1.1 200 OK\r",
+        "No response received"
+      ]
+    }
+    let(:headers_only_output) {
+      [
+        "####################",
+        "# Request:",
+        "####################",
+        "%clr%bld%redGET / HTTP/1.1",
+        "Host: www.google.com%clr",
+        "####################",
+        "# Response:",
+        "####################",
+        "%clr%bld%bluHTTP/1.1 302 Found\r",
         "\r",
-        "HTTP/1.1 302 Found",
+        "%clr"
+      ]
+    }
+    let(:http_trace_colors_output) {
+      [
+        "####################",
+        "# Request:",
+        "####################",
+        "%clr%bld%bluGET / HTTP/1.1",
+        "Host: www.google.com%clr",
+        "####################",
+        "# Response:",
+        "####################",
+        "%clr%bld%grnHTTP/1.1 302 Found\r",
+        "\r",
         "Location: https://www.google.com/?gws_rd=ssl%clr"
       ]
     }
@@ -120,9 +114,19 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
       expect(@output).to eq expected_output
     end
 
-    it 'should give ideal message for nil response' do
-      subject.set_http_trace_proc(true, false, nil).call(sample_request, sample_response)
+    it 'should give "no response received" message for nil response' do
+      subject.set_http_trace_proc(true, false, nil).call(sample_request, nil)
       expect(@output).to eq nil_response_output
+    end
+
+    it 'should log HTTP headers only when HttpTraceHeadersOnly is set' do
+      subject.set_http_trace_proc(true, true, nil).call(sample_request, sample_response)
+      expect(@output).to eq headers_only_output
+    end
+
+    it 'should log the requests and responses in the specified color' do
+      subject.set_http_trace_proc(true, false, 'blu/grn').call(sample_request, sample_response)
+      expect(@output).to eq http_trace_colors_output
     end
   end
 

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -37,7 +37,10 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
 
   describe '#set_http_trace_proc' do
     let(:sample_request) {
-      "GET / HTTP/1.1\nHost: www.google.com"
+      req = Rex::Proto::Http::ClientRequest.new({"agent" => "Met",
+                                                 "data" => "bufaction=verifyLogin&user=admin&password=turnkey"
+      })
+      req
     }
 
     let(:sample_response) {
@@ -51,8 +54,12 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
         "####################",
         "# Request:",
         "####################",
-        "%clr%bld%redGET / HTTP/1.1",
-        "Host: www.google.com%clr",
+        "%clr%bld%redGET / HTTP/1.1\r",
+        "Host: \r",
+        "User-Agent: Met\r",
+        "Content-Length: 49\r",
+        "\r",
+        "bufaction=verifyLogin&user=admin&password=turnkey%clr",
         "####################",
         "# Response:",
         "####################",
@@ -67,36 +74,29 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
         "####################",
         "# Request:",
         "####################",
-        "%clr%bld%redGET / HTTP/1.1",
-        "Host: www.google.com%clr",
+        "%clr%bld%redGET / HTTP/1.1\r",
+        "Host: \r",
+        "User-Agent: Met\r",
+        "Content-Length: 49\r",
+        "\r",
+        "bufaction=verifyLogin&user=admin&password=turnkey%clr",
         "####################",
         "# Response:",
         "####################",
         "No response received"
       ]
-    }
-
-    let(:nil_request_output) {
-      [
-        "####################",
-        "# Request:",
-        "####################",
-        "%clr%bld%red%clr",
-        "####################",
-        "# Response:",
-        "####################",
-        "No response received"
-      ]
-    }
-
+    } 
 
     let(:headers_only_output) {
       [
         "####################",
         "# Request:",
         "####################",
-        "%clr%bld%redGET / HTTP/1.1",
-        "Host: www.google.com%clr",
+        "%clr%bld%redGET / HTTP/1.1\r",
+        "Host: \r",
+        "User-Agent: Met\r",
+        "Content-Length: 49\r",
+        "%clr",
         "####################",
         "# Response:",
         "####################",
@@ -111,8 +111,12 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
         "####################",
         "# Request:",
         "####################",
-        "%clr%bld%bluGET / HTTP/1.1",
-        "Host: www.google.com%clr",
+        "%clr%bld%bluGET / HTTP/1.1\r",
+        "Host: \r",
+        "User-Agent: Met\r",
+        "Content-Length: 49\r",
+        "\r",
+        "bufaction=verifyLogin&user=admin&password=turnkey%clr",
         "####################",
         "# Response:",
         "####################",
@@ -127,8 +131,12 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
         "####################",
         "# Request:",
         "####################",
-        "%clr%bld%yelGET / HTTP/1.1",
-        "Host: www.google.com%clr",
+        "%clr%bld%yelGET / HTTP/1.1\r",
+        "Host: \r",
+        "User-Agent: Met\r",
+        "Content-Length: 49\r",
+        "\r",
+        "bufaction=verifyLogin&user=admin&password=turnkey%clr",
         "####################",
         "# Response:",
         "####################",
@@ -143,8 +151,12 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
         "####################",
         "# Request:",
         "####################",
-        "%clrGET / HTTP/1.1",
-        "Host: www.google.com%clr",
+        "%clrGET / HTTP/1.1\r",
+        "Host: \r",
+        "User-Agent: Met\r",
+        "Content-Length: 49\r",
+        "\r",
+        "bufaction=verifyLogin&user=admin&password=turnkey%clr",
         "####################",
         "# Response:",
         "####################",
@@ -159,8 +171,12 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
         "####################",
         "# Request:",
         "####################",
-        "%clrGET / HTTP/1.1",
-        "Host: www.google.com%clr",
+        "%clrGET / HTTP/1.1\r",
+        "Host: \r",
+        "User-Agent: Met\r",
+        "Content-Length: 49\r",
+        "\r",
+        "bufaction=verifyLogin&user=admin&password=turnkey%clr",
         "####################",
         "# Response:",
         "####################",
@@ -183,12 +199,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
       subject.set_http_trace_proc(true, false, nil).call(sample_request, nil)
       expect(@output).to eq nil_response_output
     end
-
-    it 'should log empty message for nil request' do
-      subject.set_http_trace_proc(true, false, nil).call(nil, nil)
-      expect(@output).to eq nil_request_output
-    end
-
+ 
     it 'should log HTTP headers only when HttpTraceHeadersOnly is set' do
       subject.set_http_trace_proc(true, true, nil).call(sample_request, sample_response)
       expect(@output).to eq headers_only_output

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
         "####################",
         "# Request:",
         "####################",
-        "%clr%bld%GET / HTTP/1.1",
+        "%clrGET / HTTP/1.1",
         "Host: www.google.com%clr",
         "####################",
         "# Response:",

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -4,6 +4,7 @@ require 'metasploit/framework/login_scanner/http'
 
 RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
 
+  include_context 'Msf::UIDriver'
   it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
   it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'
   it_behaves_like 'Metasploit::Framework::LoginScanner::HTTP'
@@ -22,6 +23,12 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
     allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect)
   end
 
+
+
+  #def execute_proc(procc)
+  #  procc.callback
+  #end
+
   describe '#send_request' do
     context 'when a valid request is sent' do
       it 'returns a response object' do
@@ -30,10 +37,21 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
     end
   end
 
+  #describe '#check_output' do
+  #  context 'when proc a executed' do
+  #    it 'print requests and responses' do
+  #      dbl = double
+  #      let(:request) {"Hi Request"}
+  #      let(:response) {"Hi Response"}
+  #      allow(dbl).to receive(:foo) { |&block| block.call(request, response) }
+  #      expect { |probe| dbl.foo(&probe) }.to yield_with_args(14)
+  #    end
+  #  end
+  #end
+
   describe '#set_http_trace_proc' do
     it 'configures http tracing' do
-      expect(subject.set_http_trace_proc(true)).to be_kind_of(Proc) 
-      expect{subject.send_request({'uri'=>'/'})}.to output('Request').to_stdout
+      expect(subject.set_http_trace_proc(true)).to be_kind_of(Proc)
     end
   end
 

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -67,6 +67,20 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
         "####################",
         "# Request:",
         "####################",
+        "%clr%bld%redGET / HTTP/1.1",
+        "Host: www.google.com%clr",
+        "####################",
+        "# Response:",
+        "####################",
+        "No response received"
+      ]
+    }
+
+    let(:nil_request_output) {
+      [
+        "####################",
+        "# Request:",
+        "####################",
         "%clr%bld%red%clr",
         "####################",
         "# Response:",
@@ -74,6 +88,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
         "No response received"
       ]
     }
+
 
     let(:headers_only_output) {
       [
@@ -133,8 +148,13 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
     end 
 
     it 'should give "no response received" message for nil response' do
-      subject.set_http_trace_proc(true, false, nil).call(nil, nil)
+      subject.set_http_trace_proc(true, false, nil).call(sample_request, nil)
       expect(@output).to eq nil_response_output
+    end
+
+    it 'should log empty message for nil request' do
+      subject.set_http_trace_proc(true, false, nil).call(nil, nil)
+      expect(@output).to eq nil_request_output
     end
 
     it 'should log HTTP headers only when HttpTraceHeadersOnly is set' do

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -1,12 +1,11 @@
-
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/http'
 
 RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
   include_context 'Msf::UIDriver'
   include_context 'Msf::Simple::Framework'
-  
-  it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
+
+  it_behaves_like 'Metasploit::Framework::LoginScanner::Base', has_realm_key: true, has_default_realm: false
   it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'
   it_behaves_like 'Metasploit::Framework::LoginScanner::HTTP'
 
@@ -30,167 +29,168 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
   describe '#send_request' do
     context 'when a valid request is sent' do
       it 'returns a response object' do
-        expect(subject.send_request({'uri'=>'/'})).to be_kind_of(Rex::Proto::Http::Response)
+        expect(subject.send_request({ 'uri' => '/' })).to be_kind_of(Rex::Proto::Http::Response)
       end
     end
   end
 
   describe '#set_http_trace_proc' do
-    let(:sample_request) {
-      req = Rex::Proto::Http::ClientRequest.new({"agent" => "Met",
-                                                 "data" => "bufaction=verifyLogin&user=admin&password=turnkey"
+    let(:sample_request) do
+      req = Rex::Proto::Http::ClientRequest.new({
+        'agent' => 'Met',
+        'data' => 'bufaction=verifyLogin&user=admin&password=turnkey'
       })
       req
-    }
+    end
 
-    let(:sample_response) {
-      res = Rex::Proto::Http::Response.new(302,'Found')
-      allow(res).to receive(:body).and_return("Location: https://www.google.com/?gws_rd=ssl")
+    let(:sample_response) do
+      res = Rex::Proto::Http::Response.new(302, 'Found')
+      allow(res).to receive(:body).and_return('Location: https://www.google.com/?gws_rd=ssl')
       res
-    }
+    end
 
-    let(:normal_request_response_output) {
+    let(:normal_request_response_output) do
       [
-        "####################",
-        "# Request:",
-        "####################",
+        '####################',
+        '# Request:',
+        '####################',
         "%clr%bld%redGET / HTTP/1.1\r",
         "Host: \r",
         "User-Agent: Met\r",
         "Content-Length: 49\r",
         "\r",
-        "bufaction=verifyLogin&user=admin&password=turnkey%clr",
-        "####################",
-        "# Response:",
-        "####################",
+        'bufaction=verifyLogin&user=admin&password=turnkey%clr',
+        '####################',
+        '# Response:',
+        '####################',
         "%clr%bld%bluHTTP/1.1 302 Found\r",
         "\r",
-        "Location: https://www.google.com/?gws_rd=ssl%clr"
+        'Location: https://www.google.com/?gws_rd=ssl%clr'
       ]
-    }
+    end
 
-    let(:nil_response_output) {
+    let(:nil_response_output) do
       [
-        "####################",
-        "# Request:",
-        "####################",
+        '####################',
+        '# Request:',
+        '####################',
         "%clr%bld%redGET / HTTP/1.1\r",
         "Host: \r",
         "User-Agent: Met\r",
         "Content-Length: 49\r",
         "\r",
-        "bufaction=verifyLogin&user=admin&password=turnkey%clr",
-        "####################",
-        "# Response:",
-        "####################",
-        "No response received"
+        'bufaction=verifyLogin&user=admin&password=turnkey%clr',
+        '####################',
+        '# Response:',
+        '####################',
+        'No response received'
       ]
-    } 
+    end
 
-    let(:headers_only_output) {
+    let(:headers_only_output) do
       [
-        "####################",
-        "# Request:",
-        "####################",
+        '####################',
+        '# Request:',
+        '####################',
         "%clr%bld%redGET / HTTP/1.1\r",
         "Host: \r",
         "User-Agent: Met\r",
         "Content-Length: 49\r",
-        "%clr",
-        "####################",
-        "# Response:",
-        "####################",
+        '%clr',
+        '####################',
+        '# Response:',
+        '####################',
         "%clr%bld%bluHTTP/1.1 302 Found\r",
         "\r",
-        "%clr"
+        '%clr'
       ]
-    }
+    end
 
-    let(:http_trace_colors_output) {
+    let(:http_trace_colors_output) do
       [
-        "####################",
-        "# Request:",
-        "####################",
+        '####################',
+        '# Request:',
+        '####################',
         "%clr%bld%bluGET / HTTP/1.1\r",
         "Host: \r",
         "User-Agent: Met\r",
         "Content-Length: 49\r",
         "\r",
-        "bufaction=verifyLogin&user=admin&password=turnkey%clr",
-        "####################",
-        "# Response:",
-        "####################",
+        'bufaction=verifyLogin&user=admin&password=turnkey%clr',
+        '####################',
+        '# Response:',
+        '####################',
         "%clr%bld%grnHTTP/1.1 302 Found\r",
         "\r",
-        "Location: https://www.google.com/?gws_rd=ssl%clr"
+        'Location: https://www.google.com/?gws_rd=ssl%clr'
       ]
-    }
+    end
 
-    let(:http_trace_single_color_output) {
+    let(:http_trace_single_color_output) do
       [
-        "####################",
-        "# Request:",
-        "####################",
+        '####################',
+        '# Request:',
+        '####################',
         "%clr%bld%yelGET / HTTP/1.1\r",
         "Host: \r",
         "User-Agent: Met\r",
         "Content-Length: 49\r",
         "\r",
-        "bufaction=verifyLogin&user=admin&password=turnkey%clr",
-        "####################",
-        "# Response:",
-        "####################",
+        'bufaction=verifyLogin&user=admin&password=turnkey%clr',
+        '####################',
+        '# Response:',
+        '####################',
         "%clrHTTP/1.1 302 Found\r",
         "\r",
-        "Location: https://www.google.com/?gws_rd=ssl%clr"
+        'Location: https://www.google.com/?gws_rd=ssl%clr'
       ]
-    }
+    end
 
-    let(:http_trace_single_color_output_leading_slash) {
+    let(:http_trace_single_color_output_leading_slash) do
       [
-        "####################",
-        "# Request:",
-        "####################",
+        '####################',
+        '# Request:',
+        '####################',
         "%clrGET / HTTP/1.1\r",
         "Host: \r",
         "User-Agent: Met\r",
         "Content-Length: 49\r",
         "\r",
-        "bufaction=verifyLogin&user=admin&password=turnkey%clr",
-        "####################",
-        "# Response:",
-        "####################",
+        'bufaction=verifyLogin&user=admin&password=turnkey%clr',
+        '####################',
+        '# Response:',
+        '####################',
         "%clr%bld%yelHTTP/1.1 302 Found\r",
         "\r",
-        "Location: https://www.google.com/?gws_rd=ssl%clr"
+        'Location: https://www.google.com/?gws_rd=ssl%clr'
       ]
-    }
+    end
 
-    let(:http_trace_no_color_output) {
+    let(:http_trace_no_color_output) do
       [
-        "####################",
-        "# Request:",
-        "####################",
+        '####################',
+        '# Request:',
+        '####################',
         "%clrGET / HTTP/1.1\r",
         "Host: \r",
         "User-Agent: Met\r",
         "Content-Length: 49\r",
         "\r",
-        "bufaction=verifyLogin&user=admin&password=turnkey%clr",
-        "####################",
-        "# Response:",
-        "####################",
+        'bufaction=verifyLogin&user=admin&password=turnkey%clr',
+        '####################',
+        '# Response:',
+        '####################',
         "%clrHTTP/1.1 302 Found\r",
         "\r",
-        "Location: https://www.google.com/?gws_rd=ssl%clr"
+        'Location: https://www.google.com/?gws_rd=ssl%clr'
       ]
-    }
+    end
 
     it 'returns a proc object when HttpTrace is set to true' do
       expect(subject.set_http_trace_proc(true, false, nil)).to be_kind_of(Proc)
     end
 
-    it 'should execute the proc when defined' do
+    it 'should output the provided request and response with headers when HttpTrace is set' do
       subject.set_http_trace_proc(true, false, nil).call(sample_request, sample_response)
       expect(@output).to eq normal_request_response_output
     end
@@ -199,7 +199,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
       subject.set_http_trace_proc(true, false, nil).call(sample_request, nil)
       expect(@output).to eq nil_response_output
     end
- 
+
     it 'should log HTTP headers only when HttpTraceHeadersOnly is set' do
       subject.set_http_trace_proc(true, true, nil).call(sample_request, sample_response)
       expect(@output).to eq headers_only_output
@@ -210,17 +210,17 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
       expect(@output).to eq normal_request_response_output
     end
 
-    it 'should log HTTP requests and responses in the specified color' do
+    it 'should log HTTP requests and responses in the respective colors specified' do
       subject.set_http_trace_proc(true, false, 'blu/grn').call(sample_request, sample_response)
       expect(@output).to eq http_trace_colors_output
     end
 
-    it 'should only log HTTP request in color when only one colour is specified' do
+    it 'should only log HTTP request in color when only one color is specified followed by a trailing "/"' do
       subject.set_http_trace_proc(true, false, 'yel/').call(sample_request, sample_response)
       expect(@output).to eq http_trace_single_color_output
     end
 
-    it 'should only log HTTP response in color when only one colour is specified after a leading "/"' do
+    it 'should only log HTTP response in color when only one color is specified after a leading "/"' do
       subject.set_http_trace_proc(true, false, '/yel').call(sample_request, sample_response)
       expect(@output).to eq http_trace_single_color_output_leading_slash
     end
@@ -230,7 +230,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
       expect(@output).to eq http_trace_no_color_output
     end
 
-    it 'should only log HTTP request in color when only one color is specified without "/"' do
+    it 'should only log HTTP request in color when only one color is specified without any "/"s' do
       subject.set_http_trace_proc(true, false, 'yel').call(sample_request, sample_response)
       expect(@output).to eq http_trace_single_color_output
     end
@@ -243,5 +243,4 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
       expect(subject.set_http_trace_proc(nil, false, nil)).to be_nil
     end
   end
-
 end

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -32,14 +32,15 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
 
   describe '#set_http_trace_proc' do
     it 'configures http tracing' do
-      expect(subject.set_http_trace_proc(true)).to be_kind_of(Proc)
+      expect(subject.set_http_trace_proc(true)).to be_kind_of(Proc) 
+      expect{subject.send_request({'uri'=>'/'})}.to output('Request').to_stdout
     end
   end
 
-  #describe '#unset_http_client_proc' do
-  #  it 'does not log http tracing' do
-  #    expect(subject.set_http_client_proc(false) should be nil
-  #  end
-  #end
+  describe '#unset_http_trace_proc' do
+    it 'does not log http tracing' do
+      expect(subject.set_http_trace_proc(false)).to be_nil
+    end
+  end
 
 end

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -5,21 +5,21 @@ require 'rex'
 
 RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
   include_context 'Msf::UIDriver'
+  include_context 'Msf::Simple::Framework'
+
   class Metasploit::Framework::LoginScanner::HTTP
     def print_line(mesg='')
       print(mesg+"\n")
     end
   end
 
-  class Metasploit::Framework::LoginScanner::HTTP
-    def to_terminal_output(headers_only: false)
-      output_packet(true, headers_only: headers_only)
+  class Rex::Proto::Http::Packet
+    def to_terminal_output(headers_only=false)
+      output_packet(true, headers_only=headers_only)
     end
-  end
 
-  class Metasploit::Framework::LoginScanner::HTTP
-    def to_s(headers_only: false)
-      output_packet(false, headers_only: headers_only)
+    def to_s(headers_only=false)
+      output_packet(false, headers_only=headers_only)
     end
   end
 
@@ -34,7 +34,8 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
   it_behaves_like 'Metasploit::Framework::LoginScanner::HTTP'
 
   subject do
-    described_class.new
+    #require 'pry';binding.pry
+    described_class.new(driver)
   end
 
   let(:response) { Rex::Proto::Http::Response.new(200, 'OK') }

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -1,8 +1,13 @@
 
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/http'
+require 'rex'
 
 RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
+  include_context 'Msf::UIDriver'
+  def print_line(msg='')
+    puts(msg+'\n')
+  end
 
   it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
   it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'
@@ -38,28 +43,28 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
       "HTTP/1.1 302 Found\nLocation: https://www.google.com/?gws_rd=ssl"
     }
     let(:expected_output) {
-      "####################\n# Request : \n####################\nGET / HTTP/1.1\nHost: www.google.com\n####################\n# Response : \n####################\nHTTP/1.1 302 Found\nLocation: https://www.google.com/?gws_rd=ssl\n"
+      "####################\n# Request:\n####################\nGET / HTTP/1.1\nHost: www.google.com\n####################\n# Response:\n####################\nHTTP/1.1 302 Found\nLocation: https://www.google.com/?gws_rd=ssl\n"
     }
     let(:nil_response_output) {
-      "####################\n# Request : \n####################\nGET / HTTP/1.1\nHost: www.google.com\n####################\n# Response : \n####################\nNo response received\n"
+      "####################\n# Request:\n####################\nGET / HTTP/1.1\nHost: www.google.com\n####################\n# Response:\n####################\nNo response received\n"
     }
 
     it 'returns a proc object when HttpTrace is set to true' do
-      expect(subject.set_http_trace_proc(true)).to be_kind_of(Proc)
+      expect(subject.set_http_trace_proc(true, false, nil)).to be_kind_of(Proc)
     end
 
-    #it 'should execute the proc when defined' do
-    #  expect { subject.set_http_trace_proc(true).call(sample_request, sample_response) }.to output(expected_output).to_stdout
-    #end
+    it 'should execute the proc when defined' do
+      expect { subject.set_http_trace_proc(true, false, nil).call(sample_request, sample_response) }.to output(expected_output).to_stdout
+    end
 
-    #it 'should give ideal message for nil response' do
-    #  expect { subject.set_http_trace_proc(true).call(sample_request, nil) }.to output(nil_response_output).to_stdout
-    #end
+    it 'should give ideal message for nil response' do
+      expect { subject.set_http_trace_proc(true, false, nil).call(sample_request, nil) }.to output(nil_response_output).to_stdout
+    end
   end
 
   describe '#set_http_trace_proc' do
     it 'returns nil when HttpTrace is set to false' do
-      expect(subject.set_http_trace_proc(false)).to be_nil
+      expect(subject.set_http_trace_proc(false, false, nil)).to be_nil
     end
   end
 

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -4,7 +4,6 @@ require 'metasploit/framework/login_scanner/http'
 
 RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
 
-  include_context 'Msf::UIDriver'
   it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
   it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'
   it_behaves_like 'Metasploit::Framework::LoginScanner::HTTP'
@@ -23,12 +22,6 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
     allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect)
   end
 
-
-
-  #def execute_proc(procc)
-  #  procc.callback
-  #end
-
   describe '#send_request' do
     context 'when a valid request is sent' do
       it 'returns a response object' do
@@ -37,25 +30,13 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
     end
   end
 
-  #describe '#check_output' do
-  #  context 'when proc a executed' do
-  #    it 'print requests and responses' do
-  #      dbl = double
-  #      let(:request) {"Hi Request"}
-  #      let(:response) {"Hi Response"}
-  #      allow(dbl).to receive(:foo) { |&block| block.call(request, response) }
-  #      expect { |probe| dbl.foo(&probe) }.to yield_with_args(14)
-  #    end
-  #  end
-  #end
-
   describe '#set_http_trace_proc' do
     it 'configures http tracing' do
       expect(subject.set_http_trace_proc(true)).to be_kind_of(Proc)
     end
   end
 
-  describe '#unset_http_trace_proc' do
+  describe '#set_http_trace_proc' do
     it 'does not log http tracing' do
       expect(subject.set_http_trace_proc(false)).to be_nil
     end

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -31,13 +31,34 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
   end
 
   describe '#set_http_trace_proc' do
-    it 'configures http tracing' do
+    let(:sample_request) {
+      "GET / HTTP/1.1\nHost: www.google.com"
+    }
+    let(:sample_response) {
+      "HTTP/1.1 302 Found\nLocation: https://www.google.com/?gws_rd=ssl"
+    }
+    let(:expected_output) {
+      "####################\n# Request : \n####################\nGET / HTTP/1.1\nHost: www.google.com\n####################\n# Response : \n####################\nHTTP/1.1 302 Found\nLocation: https://www.google.com/?gws_rd=ssl\n"
+    }
+    let(:nil_response_output) {
+      "####################\n# Request : \n####################\nGET / HTTP/1.1\nHost: www.google.com\n####################\n# Response : \n####################\nNo response received\n"
+    }
+
+    it 'returns a proc object when HttpTrace is set to true' do
       expect(subject.set_http_trace_proc(true)).to be_kind_of(Proc)
     end
+
+    #it 'should execute the proc when defined' do
+    #  expect { subject.set_http_trace_proc(true).call(sample_request, sample_response) }.to output(expected_output).to_stdout
+    #end
+
+    #it 'should give ideal message for nil response' do
+    #  expect { subject.set_http_trace_proc(true).call(sample_request, nil) }.to output(nil_response_output).to_stdout
+    #end
   end
 
   describe '#set_http_trace_proc' do
-    it 'does not log http tracing' do
+    it 'returns nil when HttpTrace is set to false' do
       expect(subject.set_http_trace_proc(false)).to be_nil
     end
   end

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -5,6 +5,7 @@ require 'rex'
 
 RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
   include_context 'Msf::UIDriver'
+  include_context 'Msf::DBManager'
   include_context 'Msf::Simple::Framework'
 
   #class Metasploit::Framework::LoginScanner::HTTP
@@ -13,21 +14,21 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
   #  end
   #end
 
-  class Rex::Proto::Http::Packet
-    def to_terminal_output(headers_only=false)
-      output_packet(true, headers_only=headers_only)
-    end
+  #class Rex::Proto::Http::Packet
+  #  def to_terminal_output(headers_only=false)
+  #    output_packet(true, headers_only=headers_only)
+  #  end
 
-    def to_s(headers_only=false)
-      output_packet(false, headers_only=headers_only)
-    end
-  end
+  #  def to_s(headers_only=false)
+  #    output_packet(false, headers_only=headers_only)
+  #  end
+  #end
 
-  class Rex::Ui::Text::Output::Stdio
-    def support_color?
-      return false
-    end
-  end
+  #class Rex::Ui::Text::Output::Stdio
+  #  def support_color?
+  #    return false
+  #  end
+  #end
 
   it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
   it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -67,8 +67,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
         "####################",
         "# Request:",
         "####################",
-        "%clr%bld%redGET / HTTP/1.1",
-        "Host: www.google.com%clr",
+        "%clr%bld%red%clr",
         "####################",
         "# Response:",
         "####################",
@@ -108,6 +107,22 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
       ]
     }
 
+    let(:http_trace_single_color_output) {
+      [
+        "####################",
+        "# Request:",
+        "####################",
+        "%clr%bld%yelGET / HTTP/1.1",
+        "Host: www.google.com%clr",
+        "####################",
+        "# Response:",
+        "####################",
+        "%clrHTTP/1.1 302 Found\r",
+        "\r",
+        "Location: https://www.google.com/?gws_rd=ssl%clr"
+      ]
+    }
+
     it 'returns a proc object when HttpTrace is set to true' do
       expect(subject.set_http_trace_proc(true, false, nil)).to be_kind_of(Proc)
     end
@@ -115,10 +130,10 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
     it 'should execute the proc when defined' do
       subject.set_http_trace_proc(true, false, nil).call(sample_request, sample_response)
       expect(@output).to eq expected_output
-    end
+    end 
 
     it 'should give "no response received" message for nil response' do
-      subject.set_http_trace_proc(true, false, nil).call(sample_request, nil)
+      subject.set_http_trace_proc(true, false, nil).call(nil, nil)
       expect(@output).to eq nil_response_output
     end
 
@@ -127,13 +142,32 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
       expect(@output).to eq headers_only_output
     end
 
+    it 'should log HTTP requests and responses with body when HttpTraceHeadersOnly is unset' do
+      subject.set_http_trace_proc(true, nil, nil).call(sample_request, sample_response)
+      expect(@output).to eq expected_output
+    end
+
     it 'should log HTTP requests and responses in the specified color' do
       subject.set_http_trace_proc(true, false, 'blu/grn').call(sample_request, sample_response)
       expect(@output).to eq http_trace_colors_output
     end
 
-    it 'returns nil when HttpTrace is unset' do
+    it 'should only log HTTP request in color when only one colour is specified' do
+      subject.set_http_trace_proc(true, false, 'yel/').call(sample_request, sample_response)
+      expect(@output).to eq http_trace_single_color_output
+    end
+
+    it 'should only log HTTP request in color when only one color is specified without "/"' do
+      subject.set_http_trace_proc(true, false, 'yel').call(sample_request, sample_response)
+      expect(@output).to eq http_trace_single_color_output
+    end
+
+    it 'returns nil when HttpTrace is set to false' do
       expect(subject.set_http_trace_proc(false, false, nil)).to be_nil
+    end
+
+    it 'returns nil when HttpTrace is unset' do
+      expect(subject.set_http_trace_proc(nil, false, nil)).to be_nil
     end
   end
 

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -1,11 +1,9 @@
 
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/http'
-require 'rex'
 
 RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
   include_context 'Msf::UIDriver'
-  include_context 'Msf::DBManager'
   include_context 'Msf::Simple::Framework'
   
   it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
@@ -41,11 +39,13 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
     let(:sample_request) {
       "GET / HTTP/1.1\nHost: www.google.com"
     }
+
     let(:sample_response) {
       res = Rex::Proto::Http::Response.new(302,'Found')
       allow(res).to receive(:body).and_return("Location: https://www.google.com/?gws_rd=ssl")
       res
     }
+
     let(:expected_output) {
       [
         "####################",
@@ -61,6 +61,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
         "Location: https://www.google.com/?gws_rd=ssl%clr"
       ]
     }
+
     let(:nil_response_output) {
       [
         "####################",
@@ -74,6 +75,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
         "No response received"
       ]
     }
+
     let(:headers_only_output) {
       [
         "####################",
@@ -89,6 +91,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
         "%clr"
       ]
     }
+
     let(:http_trace_colors_output) {
       [
         "####################",
@@ -124,14 +127,12 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
       expect(@output).to eq headers_only_output
     end
 
-    it 'should log the requests and responses in the specified color' do
+    it 'should log HTTP requests and responses in the specified color' do
       subject.set_http_trace_proc(true, false, 'blu/grn').call(sample_request, sample_response)
       expect(@output).to eq http_trace_colors_output
     end
-  end
 
-  describe '#set_http_trace_proc' do
-    it 'returns nil when HttpTrace is set to false' do
+    it 'returns nil when HttpTrace is unset' do
       expect(subject.set_http_trace_proc(false, false, nil)).to be_nil
     end
   end

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
   include_context 'Msf::UIDriver'
   include_context 'Msf::Simple::Framework'
 
-  class Metasploit::Framework::LoginScanner::HTTP
-    def print_line(mesg='')
-      print(mesg+"\n")
-    end
-  end
+  #class Metasploit::Framework::LoginScanner::HTTP
+  #  def print_line(mesg='')
+  #    print(mesg+"\n")
+  #  end
+  #end
 
   class Rex::Proto::Http::Packet
     def to_terminal_output(headers_only=false)
@@ -35,7 +35,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
 
   subject do
     #require 'pry';binding.pry
-    described_class.new(driver)
+    described_class.new
   end
 
   let(:response) { Rex::Proto::Http::Response.new(200, 'OK') }

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -7,6 +7,14 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
   include_context 'Msf::UIDriver'
   include_context 'Msf::DBManager'
   include_context 'Msf::Simple::Framework'
+  
+  let(:driver) do
+    instance = double('Rex::Ui::Text::Output::Stdio', framework: framework)
+    #require 'pry';binding.pry
+    allow(instance).to receive(:print_line) { |arg| $stdout.puts arg }
+    capture_logging(instance)
+    instance
+  end
 
   #class Metasploit::Framework::LoginScanner::HTTP
   #  def print_line(mesg='')
@@ -36,7 +44,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
 
   subject do
     #require 'pry';binding.pry
-    described_class.new
+    described_class.new(driver)
   end
 
   let(:response) { Rex::Proto::Http::Response.new(200, 'OK') }
@@ -45,6 +53,8 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
     allow_any_instance_of(Rex::Proto::Http::Client).to receive(:request_cgi).with(any_args)
     allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).with(any_args).and_return(response)
     allow_any_instance_of(Rex::Proto::Http::Client).to receive(:set_config).with(any_args)
+    #allow().to receive(:print_line) { |arg| $stdout.puts arg }
+    allow(subject).to receive(:print) { |arg| $stdout.puts arg }
     allow_any_instance_of(Rex::Proto::Http::Client).to receive(:close)
     allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect)
   end

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
   it_behaves_like 'Metasploit::Framework::LoginScanner::HTTP'
 
   subject do
-    described_class.new
+    described_class.new(driver)
   end
 
   let(:response) { Rex::Proto::Http::Response.new(200, 'OK') }

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -11,6 +11,18 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
     end
   end
 
+  class Metasploit::Framework::LoginScanner::HTTP
+    def to_terminal_output(headers_only: false)
+      output_packet(true, headers_only: headers_only)
+    end
+  end
+
+  class Metasploit::Framework::LoginScanner::HTTP
+    def to_s(headers_only: false)
+      output_packet(false, headers_only: headers_only)
+    end
+  end
+
   class Rex::Ui::Text::Output::Stdio
     def support_color?
       return false
@@ -51,10 +63,10 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
       "HTTP/1.1 302 Found\nLocation: https://www.google.com/?gws_rd=ssl"
     }
     let(:expected_output) {
-      "####################\n# Request:\n####################\nGET / HTTP/1.1\nHost: www.google.com\n####################\n# Response:\n####################\nHTTP/1.1 302 Found\nLocation: https://www.google.com/?gws_rd=ssl\n"
+      "####################\n# Request:\n####################\n%clr%bld%redGET / HTTP/1.1\nHost: www.google.com%clr\n####################\n# Response:\n####################\nHTTP/1.1 302 Found\nLocation: https://www.google.com/?gws_rd=ssl\n"
     }
     let(:nil_response_output) {
-      "####################\n# Request:\n####################\nGET / HTTP/1.1\nHost: www.google.com\n####################\n# Response:\n####################\nNo response received\n"
+      "####################\n# Request:\n####################\n%clr%bld%redGET / HTTP/1.1\nHost: www.google.com%clr\n####################\n# Response:\n####################\nNo response received\n"
     }
 
     it 'returns a proc object when HttpTrace is set to true' do

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -5,8 +5,16 @@ require 'rex'
 
 RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
   include_context 'Msf::UIDriver'
-  def print_line(msg='')
-    puts(msg+'\n')
+  class Metasploit::Framework::LoginScanner::HTTP
+    def print_line(mesg='')
+      print(mesg+"\n")
+    end
+  end
+
+  class Rex::Ui::Text::Output::Stdio
+    def support_color?
+      return false
+    end
   end
 
   it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
@@ -14,7 +22,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
   it_behaves_like 'Metasploit::Framework::LoginScanner::HTTP'
 
   subject do
-    described_class.new(driver)
+    described_class.new
   end
 
   let(:response) { Rex::Proto::Http::Response.new(200, 'OK') }

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
       res
     }
 
-    let(:expected_output) {
+    let(:normal_request_response_output) {
       [
         "####################",
         "# Request:",
@@ -170,16 +170,14 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
       ]
     }
 
-
-
     it 'returns a proc object when HttpTrace is set to true' do
       expect(subject.set_http_trace_proc(true, false, nil)).to be_kind_of(Proc)
     end
 
     it 'should execute the proc when defined' do
       subject.set_http_trace_proc(true, false, nil).call(sample_request, sample_response)
-      expect(@output).to eq expected_output
-    end 
+      expect(@output).to eq normal_request_response_output
+    end
 
     it 'should give "no response received" message for nil response' do
       subject.set_http_trace_proc(true, false, nil).call(sample_request, nil)
@@ -198,7 +196,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
 
     it 'should log HTTP requests and responses with body when HttpTraceHeadersOnly is unset' do
       subject.set_http_trace_proc(true, nil, nil).call(sample_request, sample_response)
-      expect(@output).to eq expected_output
+      expect(@output).to eq normal_request_response_output
     end
 
     it 'should log HTTP requests and responses in the specified color' do

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -30,4 +30,16 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
     end
   end
 
+  describe '#set_http_trace_proc' do
+    it 'configures http tracing' do
+      expect(subject.set_http_trace_proc(true)).to be_kind_of(Proc)
+    end
+  end
+
+  #describe '#unset_http_client_proc' do
+  #  it 'does not log http tracing' do
+  #    expect(subject.set_http_client_proc(false) should be nil
+  #  end
+  #end
+
 end

--- a/spec/lib/rex/proto/http/client_spec.rb
+++ b/spec/lib/rex/proto/http/client_spec.rb
@@ -778,7 +778,7 @@ RSpec.describe Rex::Proto::Http::Client do
       expect {cli.httptrace_use_callback(sample_request, sample_response)}.to output(expected_output).to_stdout
     end
 
-    it 'should should give ideal message for nil response' do
+    it 'should give ideal message for nil response' do
       cli = Rex::Proto::Http::Client.new('127.0.0.1', http_trace_proc: http_trace_proc)
       expect {cli.httptrace_use_callback(sample_request, nil)}.to output(nil_response_output).to_stdout
     end

--- a/spec/lib/rex/proto/http/client_spec.rb
+++ b/spec/lib/rex/proto/http/client_spec.rb
@@ -778,7 +778,7 @@ RSpec.describe Rex::Proto::Http::Client do
       expect {cli.httptrace_use_callback(sample_request, sample_response)}.to output(expected_output).to_stdout
     end
 
-    it 'should give ideal message for nil response' do
+    it 'should print "No response received" message for nil response' do
       cli = Rex::Proto::Http::Client.new('127.0.0.1', http_trace_proc: http_trace_proc)
       expect {cli.httptrace_use_callback(sample_request, nil)}.to output(nil_response_output).to_stdout
     end

--- a/spec/lib/rex/proto/http/client_spec.rb
+++ b/spec/lib/rex/proto/http/client_spec.rb
@@ -745,10 +745,10 @@ RSpec.describe Rex::Proto::Http::Client do
 
   context 'with HttpTrace logging'
     let(:sample_request) {
-      "GET / HTTP/1.1\nHost: www.google.com\nUser-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.81 Safari/537.36 Edg/97.0.1072.69"
+      "GET / HTTP/1.1\nHost: www.google.com"
     }
     let(:sample_response) {
-      "HTTP/1.1 302 Found\nLocation: https://www.google.com/?gws_rd=ssl\nCache-Control: private\nContent-Type: text/html; charset=UTF-8\nServer: gws\nContent-Length: 231"
+      "HTTP/1.1 302 Found\nLocation: https://www.google.com/?gws_rd=ssl"
     }
     let(:http_trace_proc) { 
       proc { |request, response|
@@ -767,15 +767,19 @@ RSpec.describe Rex::Proto::Http::Client do
       }
     }
     let(:expected_output) {
-      "####################\n# Request : \n####################\nGET / HTTP/1.1\nHost: www.google.com\nUser-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.81 Safari/537.36 Edg/97.0.1072.69\n####################\n# Response : \n####################\nHTTP/1.1 302 Found\nLocation: https://www.google.com/?gws_rd=ssl\nCache-Control: private\nContent-Type: text/html; charset=UTF-8\nServer: gws\nContent-Length: 231"
-    }    
-    it 'should execute a proc when defined' do
+      "####################\n# Request : \n####################\nGET / HTTP/1.1\nHost: www.google.com\n####################\n# Response : \n####################\nHTTP/1.1 302 Found\nLocation: https://www.google.com/?gws_rd=ssl\n"
+    }
+    let(:nil_response_output) {
+      "####################\n# Request : \n####################\nGET / HTTP/1.1\nHost: www.google.com\n####################\n# Response : \n####################\nNo response received\n"
+    } 
+
+    it 'should execute the proc when defined' do
       cli = Rex::Proto::Http::Client.new('127.0.0.1', http_trace_proc: http_trace_proc)
       expect {cli.httptrace_use_callback(sample_request, sample_response)}.to output(expected_output).to_stdout
     end
 
     it 'should should give ideal message for nil response' do
       cli = Rex::Proto::Http::Client.new('127.0.0.1', http_trace_proc: http_trace_proc)
-      expect {cli.httptrace_use_callback(sample_request, nil)}.to output(expected_output).to_stdout
+      expect {cli.httptrace_use_callback(sample_request, nil)}.to output(nil_response_output).to_stdout
     end
 end

--- a/spec/lib/rex/proto/http/client_spec.rb
+++ b/spec/lib/rex/proto/http/client_spec.rb
@@ -1,52 +1,49 @@
 # -*- coding:binary -*-
 
-# Note: Some of these tests require a failed
+# NOTE: Some of these tests require a failed
 # connection to 127.0.0.1:1. If you have some crazy local
 # firewall that is dropping packets to this, your tests
 # might be slow.
 RSpec.describe Rex::Proto::Http::Client do
-
   class << self
 
     # Set a standard excuse that indicates that the method
     # under test needs to be first examined to figure out
     # what's sane and what's not.
-    def excuse_lazy(test_method=nil)
-      ret = "need to determine pass/fail criteria"
+    def excuse_lazy(test_method = nil)
+      ret = 'need to determine pass/fail criteria'
       test_method ? ret << " for #{test_method.inspect}" : ret
     end
 
     # Complain about not having a "real" connection (can be mocked)
     def excuse_needs_connection
-      "need to actually set up an HTTP server to test"
+      'need to actually set up an HTTP server to test'
     end
 
     # Complain about not having a real auth server (can be mocked)
     def excuse_needs_auth
-      "need to set up an HTTP authentication challenger"
+      'need to set up an HTTP authentication challenger'
     end
 
   end
 
-  let(:ip) { "1.2.3.4" }
+  let(:ip) { '1.2.3.4' }
 
   subject(:cli) do
     Rex::Proto::Http::Client.new(ip)
   end
 
-  describe "#set_config" do
-
-    it "should respond to #set_config" do
+  describe '#set_config' do
+    it 'should respond to #set_config' do
       expect(cli.set_config).to eq({})
     end
-
   end
 
-  it "should respond to initialize" do
+  it 'should respond to initialize' do
     expect(cli).to be
   end
 
-  it "should have a set of default instance variables" do
+  it 'should have a set of default instance variables' do
     expect(cli.instance_variable_get(:@hostname)).to eq ip
     expect(cli.instance_variable_get(:@port)).to eq 80
     expect(cli.instance_variable_get(:@context)).to eq({})
@@ -57,36 +54,36 @@ RSpec.describe Rex::Proto::Http::Client do
     expect(cli.config).to be_a_kind_of Hash
   end
 
-  it "should produce a raw HTTP request" do
+  it 'should produce a raw HTTP request' do
     expect(cli.request_raw).to be_a_kind_of Rex::Proto::Http::ClientRequest
   end
 
-  it "should produce a CGI HTTP request" do
+  it 'should produce a CGI HTTP request' do
     req = cli.request_cgi
     expect(req).to be_a_kind_of Rex::Proto::Http::ClientRequest
   end
 
-  context "with authorization" do
+  context 'with authorization' do
     subject(:cli) do
       cli = Rex::Proto::Http::Client.new(ip)
-      cli.set_config({"authorization" => "Basic base64dstuffhere"})
+      cli.set_config({ 'authorization' => 'Basic base64dstuffhere' })
       cli
     end
-    let(:user)   { "user" }
-    let(:pass)   { "pass" }
-    let(:base64) { ["user:pass"].pack('m').chomp }
+    let(:user) { 'user' }
+    let(:pass) { 'pass' }
+    let(:base64) { ['user:pass'].pack('m').chomp }
 
-    context "and an Authorization header" do
+    context 'and an Authorization header' do
       before do
-        cli.set_config({"headers" => { "Authorization" => "Basic #{base64}" } })
+        cli.set_config({ 'headers' => { 'Authorization' => "Basic #{base64}" } })
       end
-      it "should have one Authorization header" do
+      it 'should have one Authorization header' do
         req = cli.request_cgi
-        match = req.to_s.match("Authorization: Basic")
+        match = req.to_s.match('Authorization: Basic')
         expect(match).to be
         expect(match.length).to eq 1
       end
-      it "should prefer the value in the header" do
+      it 'should prefer the value in the header' do
         req = cli.request_cgi
         match = req.to_s.match(/Authorization: Basic (.*)$/)
         expect(match).to be
@@ -96,26 +93,26 @@ RSpec.describe Rex::Proto::Http::Client do
     end
   end
 
-  context "with credentials" do
+  context 'with credentials' do
     subject(:cli) do
       cli = Rex::Proto::Http::Client.new(ip)
       cli
     end
-    let(:first_response) {
+    let(:first_response) do
       "HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\nWWW-Authenticate: Basic realm=\"foo\"\r\n\r\n"
-    }
-    let(:authed_response) {
+    end
+    let(:authed_response) do
       "HTTP/1.1 200 Ok\r\nContent-Length: 0\r\n\r\n"
-    }
-    let(:user) { "user" }
-    let(:pass) { "pass" }
+    end
+    let(:user) { 'user' }
+    let(:pass) { 'pass' }
 
-    it "should not send creds on the first request in order to induce a 401" do
+    it 'should not send creds on the first request in order to induce a 401' do
       req = subject.request_cgi
-      expect(req.to_s).not_to match("Authorization:")
+      expect(req.to_s).not_to match('Authorization:')
     end
 
-    it "should send creds after receiving a 401" do
+    it 'should send creds after receiving a 401' do
       conn = double
       allow(conn).to receive(:put)
       allow(conn).to receive(:peerinfo)
@@ -125,11 +122,11 @@ RSpec.describe Rex::Proto::Http::Client do
 
       expect(conn).to receive(:get_once).and_return(first_response, authed_response)
       expect(conn).to receive(:put) do |str_request|
-        expect(str_request).not_to include("Authorization")
+        expect(str_request).not_to include('Authorization')
         nil
       end
       expect(conn).to receive(:put) do |str_request|
-        expect(str_request).to include("Authorization")
+        expect(str_request).to include('Authorization')
         nil
       end
 
@@ -137,82 +134,75 @@ RSpec.describe Rex::Proto::Http::Client do
 
       allow(Rex::Socket::Tcp).to receive(:create).and_return(conn)
 
-      opts = { "username" => user, "password" => pass}
+      opts = { 'username' => user, 'password' => pass }
       req = cli.request_cgi(opts)
       cli.send_recv(req)
 
       # Make sure it didn't modify the argument
-      expect(opts).to eq({ "username" => user, "password" => pass})
+      expect(opts).to eq({ 'username' => user, 'password' => pass })
     end
-
   end
 
-  it "should attempt to connect to a server" do
-    this_cli = Rex::Proto::Http::Client.new("127.0.0.1", 1)
+  it 'should attempt to connect to a server' do
+    this_cli = Rex::Proto::Http::Client.new('127.0.0.1', 1)
     expect { this_cli.connect(1) }.to raise_error ::Rex::ConnectionRefused
   end
 
-  it "should be able to close a connection" do
+  it 'should be able to close a connection' do
     expect(cli.close).to be_nil
   end
 
-  it "should send a request and receive a response", :skip => excuse_needs_connection do
-
+  it 'should send a request and receive a response', skip: excuse_needs_connection do
   end
 
-  it "should send a request and receive a response without auth handling", :skip => excuse_needs_connection do
-
+  it 'should send a request and receive a response without auth handling', skip: excuse_needs_connection do
   end
 
-  it "should send a request", :skip => excuse_needs_connection do
-
+  it 'should send a request', skip: excuse_needs_connection do
   end
 
-  it "should test for credentials" do
-    skip "Should actually respond to :has_creds" do
+  it 'should test for credentials' do
+    skip 'Should actually respond to :has_creds' do
       expect(cli).not_to have_creds
-      this_cli = described_class.new("127.0.0.1", 1, {}, false, nil, nil, "user1", "pass1" )
+      this_cli = described_class.new('127.0.0.1', 1, {}, false, nil, nil, 'user1', 'pass1')
       expect(this_cli).to have_creds
     end
   end
 
-  it "should send authentication", :skip => excuse_needs_connection
+  it 'should send authentication', skip: excuse_needs_connection
 
-  it "should produce a basic authentication header" do
-    u = "user1"
-    p = "pass1"
-    b64 = ["#{u}:#{p}"].pack("m*").strip
-    expect(cli.basic_auth_header("user1","pass1")).to eq "Basic #{b64}"
+  it 'should produce a basic authentication header' do
+    u = 'user1'
+    p = 'pass1'
+    b64 = ["#{u}:#{p}"].pack('m*').strip
+    expect(cli.basic_auth_header('user1', 'pass1')).to eq "Basic #{b64}"
   end
 
-  it "should perform digest authentication", :skip => excuse_needs_auth do
-
+  it 'should perform digest authentication', skip: excuse_needs_auth do
   end
 
-  it "should perform negotiate authentication", :skip => excuse_needs_auth do
-
+  it 'should perform negotiate authentication', skip: excuse_needs_auth do
   end
 
-  it "should get a response", :skip => excuse_needs_connection do
-
+  it 'should get a response', skip: excuse_needs_connection do
   end
 
-  it "should end a connection with a stop" do
+  it 'should end a connection with a stop' do
     expect(cli.stop).to be_nil
   end
 
-  it "should test if a connection is valid" do
+  it 'should test if a connection is valid' do
     expect(cli.conn?).to be_falsey
   end
 
-  it "should tell if pipelining is enabled" do
+  it 'should tell if pipelining is enabled' do
     expect(cli).not_to be_pipelining
-    this_cli = Rex::Proto::Http::Client.new("127.0.0.1", 1)
+    this_cli = Rex::Proto::Http::Client.new('127.0.0.1', 1)
     this_cli.pipeline = true
     expect(this_cli).to be_pipelining
   end
 
-  it "should respond to its various accessors" do
+  it 'should respond to its various accessors' do
     expect(cli).to respond_to :config
     expect(cli).to respond_to :config_types
     expect(cli).to respond_to :pipeline
@@ -229,11 +219,11 @@ RSpec.describe Rex::Proto::Http::Client do
   # Not super sure why these are protected...
   # Me either...
   # Same here...
-  it "should refuse access to its protected accessors" do
-    expect {cli.ssl}.to raise_error NoMethodError
-    expect {cli.ssl_version}.to raise_error NoMethodError
-    expect {cli.hostname}.to raise_error NoMethodError
-    expect {cli.port}.to raise_error NoMethodError
+  it 'should refuse access to its protected accessors' do
+    expect { cli.ssl }.to raise_error NoMethodError
+    expect { cli.ssl_version }.to raise_error NoMethodError
+    expect { cli.hostname }.to raise_error NoMethodError
+    expect { cli.port }.to raise_error NoMethodError
   end
 
   context 'with vars_form_data' do
@@ -259,7 +249,7 @@ RSpec.describe Rex::Proto::Http::Client do
     end
 
     it 'should not include any form boundary metadata by default' do
-      request = cli.request_cgi({ })
+      request = cli.request_cgi({})
 
       expected = <<~EOF
         POST / HTTP/1.1\r
@@ -575,7 +565,7 @@ RSpec.describe Rex::Proto::Http::Client do
         ]
 
         request = cli.request_cgi({ 'vars_form_data' => vars_form_data })
-        expect { request.to_s }.to raise_error /The provided field `name` option is not valid. Expected: String/
+        expect { request.to_s }.to raise_error(/The provided field `name` option is not valid. Expected: String/)
       end
     end
 
@@ -744,42 +734,42 @@ RSpec.describe Rex::Proto::Http::Client do
   end
 
   context 'with HttpTrace logging'
-    let(:sample_request) {
-      "GET / HTTP/1.1\nHost: www.google.com"
+  let(:sample_request) do
+    "GET / HTTP/1.1\nHost: www.google.com"
+  end
+  let(:sample_response) do
+    "HTTP/1.1 302 Found\nLocation: https://www.google.com/?gws_rd=ssl"
+  end
+  let(:http_trace_proc) do
+    proc { |request, response|
+      puts('#' * 20)
+      puts('# Request:')
+      puts('#' * 20)
+      puts("#{request}")
+      puts('#' * 20)
+      puts('# Response:')
+      puts('#' * 20)
+      if response
+        puts("#{response}")
+      else
+        puts('No response received')
+      end
     }
-    let(:sample_response) {
-      "HTTP/1.1 302 Found\nLocation: https://www.google.com/?gws_rd=ssl"
-    }
-    let(:http_trace_proc) { 
-      proc { |request, response|
-        puts("#" * 20)
-        puts("# Request : ")
-        puts("#" * 20)
-        puts("#{request}")
-        puts("#" * 20)
-        puts("# Response : ")
-        puts("#" * 20)
-        if response
-          puts("#{response}")
-        else
-          puts("No response received")
-        end
-      }
-    }
-    let(:expected_output) {
-      "####################\n# Request : \n####################\nGET / HTTP/1.1\nHost: www.google.com\n####################\n# Response : \n####################\nHTTP/1.1 302 Found\nLocation: https://www.google.com/?gws_rd=ssl\n"
-    }
-    let(:nil_response_output) {
-      "####################\n# Request : \n####################\nGET / HTTP/1.1\nHost: www.google.com\n####################\n# Response : \n####################\nNo response received\n"
-    } 
+  end
+  let(:expected_output) do
+    "####################\n# Request:\n####################\nGET / HTTP/1.1\nHost: www.google.com\n####################\n# Response:\n####################\nHTTP/1.1 302 Found\nLocation: https://www.google.com/?gws_rd=ssl\n"
+  end
+  let(:nil_response_output) do
+    "####################\n# Request:\n####################\nGET / HTTP/1.1\nHost: www.google.com\n####################\n# Response:\n####################\nNo response received\n"
+  end
 
-    it 'should execute the proc when defined' do
-      cli = Rex::Proto::Http::Client.new('127.0.0.1', http_trace_proc: http_trace_proc)
-      expect {cli.httptrace_use_callback(sample_request, sample_response)}.to output(expected_output).to_stdout
-    end
+  it 'should execute the proc when defined' do
+    cli = Rex::Proto::Http::Client.new('127.0.0.1', http_trace_proc: http_trace_proc)
+    expect { cli.httptrace_use_callback(sample_request, sample_response) }.to output(expected_output).to_stdout
+  end
 
-    it 'should print "No response received" message for nil response' do
-      cli = Rex::Proto::Http::Client.new('127.0.0.1', http_trace_proc: http_trace_proc)
-      expect {cli.httptrace_use_callback(sample_request, nil)}.to output(nil_response_output).to_stdout
-    end
+  it 'should print "No response received" message for nil response' do
+    cli = Rex::Proto::Http::Client.new('127.0.0.1', http_trace_proc: http_trace_proc)
+    expect { cli.httptrace_use_callback(sample_request, nil) }.to output(nil_response_output).to_stdout
+  end
 end


### PR DESCRIPTION
Created a new method in **Metasploit::Framework::LoginScanner::HTTP#send_http_trace_proc()** which defines the proc related to HTTP-Trace. Earlier, the proc was defined in the **#send_request()** method. The **#send_request()** method works upon multiple things like crafting a HTTP request, sending the request to the server and receiving the response.  
  
Thus, it is difficult to test the HTTP-Trace proc in the vast **#send_request()** method. But the new method (**#set_http_trace_proc()**) just deals with defining the proc, thus making the code readable, modular and easier to test.  
  
Added the Rspec unit tests to check the behavior of the following methods:  
1. **Metasploit::Framework::LoginScanner::HTTP#set_http_trace_proc()**: Checks if the method returns a valid Proc object when datastore['HttpTrace'] is set to true.
2. **Rex::Proto::Http::Client#httptrace_use_callback()**: Executes the proc and checks if the output of the proc matches the expected output for a sample request/response. Also checks that a proper error message is displayed if the response received is nil.